### PR TITLE
Refactored diff and track; also added more features to TS Queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,11 +1879,11 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git2"
-version = "0.16.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "libc",
  "libgit2-sys",
  "log",
@@ -2835,9 +2835,9 @@ checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.16.2+1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
@@ -2897,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.23"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
 dependencies = [
  "cc",
  "libc",

--- a/benchmark_diffs/src/buggy_fixed.rs
+++ b/benchmark_diffs/src/buggy_fixed.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use hyper_ast::store::{
     labels::LabelStore,
-    nodes::{legion::NodeStore, HashedNodeRef},
+    nodes::legion::NodeStore,
     SimpleStores,
 };
 use hyper_ast_gen_ts_java::legion_with_refs::JavaTreeGen;
@@ -342,16 +342,15 @@ mod examples {
 #[cfg(test)]
 mod test {
     use hyper_ast::{
-        nodes::{IoOut, SyntaxSerializer, SyntaxWithIdsSerializer},
+        nodes::SyntaxWithIdsSerializer,
         store::{
-            defaults::NodeIdentifier, labels::LabelStore, nodes::legion::NodeStore, SimpleStores,
+            labels::LabelStore, nodes::legion::NodeStore, SimpleStores,
         },
-        types::{DecompressedSubtree, SimpleHyperAST, Typed},
+        types::{DecompressedSubtree, Typed},
     };
-    use std::io::stdout;
 
     use hyper_ast_cvs_git::no_space::NoSpaceNodeStoreWrapper;
-    use hyper_ast_gen_ts_xml::{legion::XmlTreeGen};
+    use hyper_ast_gen_ts_xml::legion::XmlTreeGen;
     // use hyper_ast_gen_ts_xml::types::TStore;
     use hyper_ast_cvs_git::TStore;
 
@@ -592,8 +591,8 @@ mod test {
         let dst = dst_tr.local.compressed_node;
         // let dst = tree_gen.stores.node_store.resolve(dst).get_child(&0);
 
-        let label_store = &tree_gen.stores.label_store;
-        let node_store = &tree_gen.stores.node_store;
+        // let label_store = &tree_gen.stores.label_store;
+        // let node_store = &tree_gen.stores.node_store;
         let stores = &*tree_gen.stores;
         // let node_store = &AAA {
         //     s: &tree_gen.stores.node_store,

--- a/benchmark_diffs/src/cross_repo.rs
+++ b/benchmark_diffs/src/cross_repo.rs
@@ -5,7 +5,7 @@ use hyper_ast::{
     utils::memusage_linux,
 };
 use hyper_ast_cvs_git::{
-    git::{fetch_github_repository, Repo, Forge}, maven::MavenModuleAcc,
+    maven::MavenModuleAcc,
     multi_preprocessed::PreProcessedRepositories, no_space::as_nospaces, processing::{ConfiguredRepoHandle2, ConfiguredRepoTrait, CacheHolding},
 };
 use num_traits::ToPrimitive;
@@ -107,8 +107,6 @@ pub fn windowed_commits_compare(
             log::warn!("diff of {oid_src:?} and {oid_dst:?}");
             assert_eq!(oid_src.len(),oid_dst.len());
             
-            type Caches = <hyper_ast_cvs_git::processing::file_sys::Maven as hyper_ast_cvs_git::processing::CachesHolding>::Caches;
-
             let mut src_acc = MavenModuleAcc::from("".to_string());
             let mut src_mem = hyper_ast::utils::Bytes::default(); // NOTE it does not consider the size of the root, but it is an implementation detail
             let mut src_s = 0;

--- a/benchmark_diffs/src/postprocess.rs
+++ b/benchmark_diffs/src/postprocess.rs
@@ -131,7 +131,7 @@ pub mod compressed_bf_post_process {
 
     impl PP2 {
         pub fn validity_mappings<'store: 'a, 'a, HAST, SD, DD>(
-            mut self,
+            self,
             mapper: &'a Mapper<'store, HAST, DD, SD, VecStore<u32>>,
         ) -> ValidityRes<usize>
         where
@@ -184,7 +184,6 @@ pub mod compressed_bf_post_process {
             let bf_f = self.file.read_u32::<BigEndian>().unwrap() as usize;
             let bf_l = self.file.read_u32::<BigEndian>().unwrap() as usize;
 
-            use hyper_ast::types::Typed;
             let now = Instant::now();
 
             let mut gt_bf = bitvec::bitvec![u64,bitvec::order::Lsb0; 0;bf_l];
@@ -464,7 +463,7 @@ impl SimpleJsonPostProcess {
         }
     }
     pub fn validity_mappings<'store: 'a, 'a, HAST, SD, DD>(
-        mut self,
+        self,
         mapper: &'a Mapper<'store, HAST, DD, SD, VecStore<u32>>,
     ) -> ValidityRes<Vec<diff_output::Match<diff_output::Tree>>>
     where
@@ -599,7 +598,7 @@ impl PathJsonPostProcess {
         }
     }
     pub fn validity_mappings<'store: 'a, 'a, HAST, SD, DD>(
-        mut self,
+        self,
         mapper: &'a Mapper<'store, HAST, DD, SD, VecStore<u32>>,
     ) -> ValidityRes<Vec<diff_output::Match<diff_output::Path>>>
     where
@@ -1016,7 +1015,7 @@ mod tests {
         // } = mapping;
         let MappingDurations([subtree_matcher_t, bottomup_matcher_t]) = mapping_durations.into();
 
-        let hast_timings = vec![subtree_matcher_t, bottomup_matcher_t, gen_t];
+        let hast_timings = vec![subtree_matcher_t, bottomup_matcher_t, prepare_gen_t + gen_t];
 
         dbg!(&hast_timings);
         let pp = CompressedBfPostProcess::create(&gt_out);

--- a/benchmark_diffs/src/window_combination.rs
+++ b/benchmark_diffs/src/window_combination.rs
@@ -5,17 +5,11 @@ use crate::{
     postprocess::{CompressedBfPostProcess, PathJsonPostProcess},
 };
 use hyper_ast::{
-    store::{
-        defaults::NodeIdentifier,
-        labels::DefaultLabelIdentifier,
-        nodes::legion::{HashedNodeRef, NodeStore},
-    },
-    types::{self, Children, MySlice, SimpleHyperAST, WithStats},
+    types::WithStats,
     utils::memusage_linux,
 };
 use hyper_ast_cvs_git::{
     git::fetch_github_repository, no_space::as_nospaces, preprocessed::PreProcessedRepository,
-    TStore,
 };
 use hyper_diff::algorithms::{self, ComputeTime};
 use num_traits::ToPrimitive;
@@ -342,7 +336,7 @@ mod test {
 
     use hyper_ast::{
         store::nodes::legion::HashedNodeRef,
-        types::{HyperAST, WithChildren},
+        types::WithChildren,
     };
     use hyper_diff::{
         decompressed_tree_store::{lazy_post_order::LazyPostOrder, CompletePostOrder},
@@ -558,12 +552,6 @@ mod test {
         // let dst_tr = stores.node_store.resolve(dst_tr).get_child(&0);
 
         let hyperast = as_nospaces(stores);
-        let mapper: hyper_diff::matchers::Mapper<
-            _,
-            LazyPostOrder<_, u32>,
-            LazyPostOrder<_, u32>,
-            VecStore<u32>,
-        > = hyperast.decompress_pair(&src_tr, &dst_tr).into();
         let partial_lazy = algorithms::gumtree_partial_lazy::diff(&hyperast, &src_tr, &dst_tr);
         dbg!(
             &partial_lazy.mapping_durations,

--- a/client/src/changes.rs
+++ b/client/src/changes.rs
@@ -106,7 +106,8 @@ pub(crate) fn added_deleted(
                     mapper.mapping.dst_arena.len(),
                 );
 
-                let vec_store = matching::full2(hyperast, mapper);
+                matching::full2(hyperast, &mut mapper);
+                let vec_store = mapper.mappings.clone();
 
                 dbg!();
                 entry

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -28,6 +28,7 @@ use hyper_ast::store::nodes::legion::NodeIdentifier;
 
 mod app;
 mod changes;
+mod cli;
 mod commit;
 mod examples;
 mod fetch;
@@ -38,7 +39,6 @@ mod track;
 mod utils;
 mod view;
 mod ws;
-mod cli;
 
 // #[derive(Default)]
 pub struct AppState {
@@ -95,6 +95,9 @@ impl Default for AppState {
 pub(crate) type PartialDecompCache = DashMap<NodeIdentifier, DS<PersistedNode<NodeIdentifier>>>;
 pub(crate) type MappingAloneCache =
     DashMap<(NodeIdentifier, NodeIdentifier), (MappingStage, VecStore<u32>)>;
+pub(crate) type MappingAloneCacheRef<'a> =
+    dashmap::mapref::one::Ref<'a, (NodeIdentifier, NodeIdentifier), (MappingStage, VecStore<u32>)>;
+
 pub(crate) enum MappingStage {
     Subtree,
     Bottomup,

--- a/client/src/track.rs
+++ b/client/src/track.rs
@@ -5,7 +5,9 @@ use enumset::{EnumSet, EnumSetType};
 use hyper_ast::{
     position::{
         compute_position, compute_position_and_nodes, compute_position_with_no_spaces,
-        compute_range, path_with_spaces, resolve_range,
+        compute_range, path_with_spaces,
+        position_accessors::{self, SolvedPosition, WithOffsets, WithPreOrderPath},
+        resolve_range, PrimInt,
     },
     store::{defaults::NodeIdentifier, nodes::legion::HashedNodeRef, SimpleStores},
     types::{
@@ -196,16 +198,24 @@ impl Into<EnumSet<FlagsE>> for &Flags {
 }
 
 #[derive(Deserialize, Serialize)]
-pub struct TrackingResult {
+pub struct TrackingResult<IdN, Idx> {
     pub compute_time: f64,
     commits_processed: usize,
-    src: PieceOfCode,
-    intermediary: Option<PieceOfCode>,
-    fallback: Option<PieceOfCode>,
-    matched: Vec<PieceOfCode>,
+    #[serde(bound(serialize = "IdN: Clone + Into<self::IdN>, Idx: Serialize"))]
+    src: PieceOfCode<IdN, Idx>,
+    #[serde(bound(serialize = "IdN: Clone + Into<self::IdN>, Idx: Serialize"))]
+    intermediary: Option<PieceOfCode<IdN, Idx>>,
+    #[serde(bound(serialize = "IdN: Clone + Into<self::IdN>, Idx: Serialize"))]
+    fallback: Option<PieceOfCode<IdN, Idx>>,
+    #[serde(bound(serialize = "IdN: Clone + Into<self::IdN>, Idx: Serialize"))]
+    matched: Vec<PieceOfCode<IdN, Idx>>,
 }
 
-impl IntoResponse for TrackingResult {
+// set the type of offset used to index in children list
+type Idx = u16;
+type IdN = NodeIdentifier;
+
+impl IntoResponse for TrackingResult<IdN, Idx> {
     fn into_response(self) -> axum::response::Response {
         let mut resp = serde_json::to_string(&self).unwrap().into_response();
         let headers = resp.headers_mut();
@@ -219,11 +229,11 @@ impl IntoResponse for TrackingResult {
     }
 }
 
-impl TrackingResult {
+impl<IdN, Idx> TrackingResult<IdN, Idx> {
     pub(crate) fn with_changes(
         self,
         (src_changes, dst_changes): (SrcChanges, DstChanges),
-    ) -> TrackingResultWithChanges {
+    ) -> TrackingResultWithChanges<IdN, Idx> {
         TrackingResultWithChanges {
             track: self,
             src_changes,
@@ -233,13 +243,14 @@ impl TrackingResult {
 }
 
 #[derive(Deserialize, Serialize)]
-pub struct TrackingResultWithChanges {
-    pub track: TrackingResult,
+pub struct TrackingResultWithChanges<IdN, Idx> {
+    #[serde(bound(serialize = "IdN: Clone + Into<self::IdN>, Idx: Serialize"))]
+    pub track: TrackingResult<IdN, Idx>,
     src_changes: SrcChanges,
     dst_changes: DstChanges,
 }
 
-impl IntoResponse for TrackingResultWithChanges {
+impl IntoResponse for TrackingResultWithChanges<IdN, Idx> {
     fn into_response(self) -> axum::response::Response {
         let mut resp = serde_json::to_string(&self).unwrap().into_response();
         let headers = resp.headers_mut();
@@ -263,27 +274,29 @@ impl IntoResponse for TrackingResultWithChanges {
 // }
 
 #[derive(Deserialize, Serialize, Debug)]
-pub struct PieceOfCode {
+pub struct PieceOfCode<IdN = self::IdN, Idx = usize> {
     user: String,
     name: String,
     commit: String,
-    path: Vec<usize>,
+    path: Vec<Idx>,
+    #[serde(bound(serialize = "IdN: Clone + Into<self::IdN>"))]
     #[serde(serialize_with = "custom_ser")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    path_ids: Vec<NodeIdentifier>, // WARN this is not fetched::NodeIdentifier
+    path_ids: Vec<IdN>, // WARN this is not fetched::NodeIdentifier
     file: String,
     start: usize,
     end: usize,
 }
 
-fn custom_ser<S>(x: &Vec<NodeIdentifier>, serializer: S) -> Result<S::Ok, S::Error>
+fn custom_ser<IdN: Clone + Into<self::IdN>, S>(x: &Vec<IdN>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
     use serde::ser::SerializeSeq;
     let mut seq = serializer.serialize_seq(Some(x.len()))?;
     for element in x {
-        let id: u64 = unsafe { std::mem::transmute(*element) };
+        let element: self::IdN = element.clone().into();
+        let id: u64 = unsafe { std::mem::transmute(element) };
         seq.serialize_element(&id)?;
     }
     seq.end()
@@ -317,7 +330,7 @@ pub fn track_code(
     state: SharedState,
     path: TrackingParam,
     query: TrackingQuery,
-) -> Result<TrackingResult, TrackingError> {
+) -> Result<TrackingResult<IdN, Idx>, TrackingError> {
     let now = Instant::now();
     let TrackingParam {
         user,
@@ -370,7 +383,7 @@ pub fn track_code(
         log::warn!("done construction of {commits:?} in {}", repository.spec);
         let src_oid = commits[0];
         let dst_oid = commits[1];
-        match aux(
+        match track_aux(
             state.clone(),
             &repository,
             src_oid,
@@ -454,7 +467,7 @@ pub(crate) fn track_code_at_path(
     state: SharedState,
     path: TrackingAtPathParam,
     query: TrackingQuery,
-) -> Result<TrackingResult, TrackingError> {
+) -> Result<TrackingResult<IdN, Idx>, TrackingError> {
     let now = Instant::now();
     let TrackingQuery {
         start,
@@ -487,7 +500,7 @@ pub(crate) fn track_code_at_path(
     let mut commit = commit.clone();
     let mut node_processed = 0;
     let mut commits_processed = 1;
-    let mut path: Vec<_> = path.split("/").filter_map(|x| x.parse().ok()).collect();
+    let mut path: Vec<Idx> = path.split("/").filter_map(|x| x.parse().ok()).collect();
     let mut source = None;
     while node_processed < MAX_NODES {
         commits_processed += 1;
@@ -520,7 +533,7 @@ pub(crate) fn track_code_at_path(
         } else {
             commits[1]
         };
-        match aux2(state.clone(), &repository, src_oid, dst_oid, &path, &flags) {
+        match track_aux2(state.clone(), &repository, src_oid, dst_oid, &path, &flags) {
             MappingResult::Direct { src: aaa, matches } => {
                 let aaa = aaa.globalize(repository.spec, commit);
                 let (src, intermediary) = if let Some(src) = source {
@@ -611,7 +624,7 @@ pub(crate) fn track_code_at_path_with_changes(
     state: SharedState,
     path: TrackingAtPathParam,
     query: TrackingQuery,
-) -> Result<TrackingResultWithChanges, TrackingError> {
+) -> Result<TrackingResultWithChanges<IdN, Idx>, TrackingError> {
     let now = Instant::now();
     let TrackingQuery {
         start: _,
@@ -675,7 +688,7 @@ pub(crate) fn track_code_at_path_with_changes(
                 message: "this commit has no parent".into(),
             });
         };
-        match aux2(state.clone(), &repository, src_oid, dst_oid, &path, &flags) {
+        match track_aux2(state.clone(), &repository, src_oid, dst_oid, &path, &flags) {
             MappingResult::Direct { src: aaa, matches } => {
                 let changes = changes::added_deleted(state, &repository, dst_oid, ori_oid.unwrap())
                     .map_err(|err| TrackingError {
@@ -701,6 +714,7 @@ pub(crate) fn track_code_at_path_with_changes(
                 return Ok(tracking_result.with_changes(changes));
             }
             MappingResult::Missing { src, fallback } => {
+                dbg!();
                 let changes = changes::added_deleted(state, &repository, dst_oid, ori_oid.unwrap())
                     .map_err(|err| TrackingError {
                         compute_time: now.elapsed().as_secs_f64(),
@@ -775,7 +789,7 @@ pub(crate) fn track_code_at_path_with_changes(
                     unreachable!()
                 } else {
                     let next = &next[0]; // TODO stop on branching ?
-                    dbg!(next);
+                                         // dbg!(next);
                     path = next.path.clone();
                     commit = next.commit.clone();
                 }
@@ -791,33 +805,93 @@ pub(crate) fn track_code_at_path_with_changes(
     })
 }
 
-enum MappingResult {
+enum MappingResult<IdN, Idx, T = PieceOfCode<IdN, Idx>> {
     Direct {
-        src: LocalPieceOfCode,
-        matches: Vec<PieceOfCode>,
+        src: LocalPieceOfCode<IdN, Idx>,
+        matches: Vec<T>,
     },
     Missing {
-        src: LocalPieceOfCode,
-        fallback: PieceOfCode,
+        src: LocalPieceOfCode<IdN, Idx>,
+        fallback: T,
     },
     Error(String),
     Skipped {
         nodes: usize,
-        src: LocalPieceOfCode,
-        next: Vec<PieceOfCode>,
+        src: LocalPieceOfCode<IdN, Idx>,
+        next: Vec<T>,
     },
 }
 
-struct LocalPieceOfCode {
+#[derive(Clone)]
+struct LocalPieceOfCode<IdN, Idx> {
     file: String,
     start: usize,
     end: usize,
-    path: Vec<usize>,
-    path_ids: Vec<NodeIdentifier>,
+    path: Vec<Idx>,
+    path_ids: Vec<IdN>,
 }
 
-impl LocalPieceOfCode {
-    pub(crate) fn globalize(self, spec: Repo, commit: impl ToString) -> PieceOfCode {
+impl<'a, S, IdN: Clone, Idx: Clone> From<(&S, &'a LocalPieceOfCode<IdN, Idx>)>
+    for LocalPieceOfCode<IdN, Idx>
+{
+    fn from((_, p): (&S, &'a LocalPieceOfCode<IdN, Idx>)) -> Self {
+        p.clone()
+    }
+}
+
+impl<IdN, Idx> LocalPieceOfCode<IdN, Idx> {
+    pub(crate) fn from_position(
+        pos: &hyper_ast::position::Position,
+        path: Vec<Idx>,
+        path_ids: Vec<IdN>,
+    ) -> Self {
+        let std::ops::Range { start, end } = pos.range();
+        let file = pos.file().to_str().unwrap().to_string();
+        Self {
+            file,
+            start,
+            end,
+            path,
+            path_ids,
+        }
+    }
+    pub(crate) fn from_file_and_range(
+        file: &std::path::Path,
+        range: std::ops::Range<usize>,
+        path: Vec<Idx>,
+        path_ids: Vec<IdN>,
+    ) -> Self {
+        let std::ops::Range { start, end } = range;
+        let file = file.to_str().unwrap().to_string();
+        Self {
+            file,
+            start,
+            end,
+            path,
+            path_ids,
+        }
+    }
+    pub(crate) fn from_pos<P>(pos: &P) -> Self
+    where
+        P: WithOffsets<Idx = Idx>
+            + WithPreOrderPath<IdN>
+            + hyper_ast::position::position_accessors::FileAndOffsetPostionT<IdN, IdO = usize>,
+    {
+        let mut path = vec![];
+        let mut path_ids = vec![];
+        for (o, i) in pos.iter_offsets_and_nodes() {
+            path.push(o);
+            path_ids.push(i);
+        }
+        Self {
+            file: pos.file().to_str().unwrap().to_owned(),
+            start: pos.start(),
+            end: pos.end(),
+            path,
+            path_ids,
+        }
+    }
+    pub(crate) fn globalize(self, spec: Repo, commit: impl ToString) -> PieceOfCode<IdN, Idx> {
         let LocalPieceOfCode {
             file,
             start,
@@ -837,9 +911,82 @@ impl LocalPieceOfCode {
             end,
         }
     }
+    fn map_path<Idx2, F: Fn(Idx) -> Idx2>(self, f: F) -> LocalPieceOfCode<IdN, Idx2> {
+        let LocalPieceOfCode {
+            file,
+            start,
+            end,
+            path,
+            path_ids,
+        } = self;
+        let path = path.into_iter().map(f).collect();
+        LocalPieceOfCode {
+            file,
+            start,
+            end,
+            path,
+            path_ids,
+        }
+    }
 }
 
-fn aux(
+#[derive(Clone)]
+struct AAA<IdN, Idx> {
+    start: usize,
+    end: usize,
+    path: Vec<Idx>,
+    node: IdN,
+}
+
+impl<IdN: Clone, Idx> position_accessors::SolvedPosition<IdN> for AAA<IdN, Idx> {
+    fn node(&self) -> IdN {
+        self.node.clone()
+    }
+}
+
+impl<IdN, Idx: PrimInt> position_accessors::WithPath<IdN> for AAA<IdN, Idx> {}
+
+impl<IdN, Idx: PrimInt> position_accessors::WithPreOrderOffsets for AAA<IdN, Idx> {
+    type It<'a> = std::slice::Iter<'a, Idx> where Idx: 'a, Self: 'a;
+
+    fn iter_offsets(&self) -> Self::It<'_> {
+        self.path.iter()
+    }
+}
+
+impl<IdN, Idx: PrimInt> position_accessors::WithPreOrderPath<IdN> for AAA<IdN, Idx> {
+    type ItPath = std::vec::IntoIter<(Idx, IdN)>;
+
+    fn iter_offsets_and_nodes(&self) -> Self::ItPath {
+        todo!()
+    }
+}
+
+impl<IdN, Idx: PrimInt> position_accessors::WithOffsets for AAA<IdN, Idx> {
+    type Idx = Idx;
+}
+
+impl<IdN, Idx> position_accessors::OffsetPostionT<IdN> for AAA<IdN, Idx> {
+    type IdO = usize;
+
+    fn offset(&self) -> Self::IdO {
+        self.start
+    }
+
+    fn len(&self) -> Self::IdO {
+        self.end - self.start
+    }
+
+    fn start(&self) -> Self::IdO {
+        self.start
+    }
+
+    fn end(&self) -> Self::IdO {
+        self.end
+    }
+}
+
+fn track_aux(
     state: std::sync::Arc<crate::AppState>,
     repo_handle: &impl ConfiguredRepoTrait<
         Config = hyper_ast_cvs_git::processing::ParametrizedCommitProcessorHandle,
@@ -850,7 +997,7 @@ fn aux(
     start: Option<usize>,
     end: Option<usize>,
     flags: &Flags,
-) -> MappingResult {
+) -> MappingResult<IdN, Idx> {
     let repositories = state.repositories.read().unwrap();
     let commit_src = repositories
         .get_commit(repo_handle.config(), &src_oid)
@@ -875,17 +1022,16 @@ fn aux(
     dbg!(&offsets_to_file);
     let mut path_to_target = vec![];
     let (node, offsets_in_file) = resolve_range(file_node, start.unwrap_or(0), end, stores);
-    path_to_target.extend(offsets_to_file.iter().map(|x| *x as u16));
+    path_to_target.extend(offsets_to_file.iter().map(|x| *x as Idx));
     dbg!(&node);
     dbg!(&offsets_in_file);
     let aaa = node_store.resolve(file_node);
     dbg!(aaa.try_get_bytes_len(0));
-    path_to_target.extend(offsets_in_file.iter().map(|x| *x as u16));
+    path_to_target.extend(offsets_in_file.iter().map(|x| *x as Idx));
 
-    let (start, end, target_node) =
-        compute_range(file_node, &mut offsets_in_file.into_iter(), stores);
-    dbg!(start, end);
-    dbg!(&target_node);
+    let computed_range = compute_range(file_node, &mut offsets_in_file.into_iter(), stores);
+    dbg!(computed_range.0, computed_range.1);
+    dbg!(&computed_range.2);
     let no_spaces_path_to_target = if false {
         // TODO use this version
         use hyper_ast::position;
@@ -902,33 +1048,36 @@ fn aux(
         no_spaces_path_to_target
     };
     let dst_oid = dst_oid; // WARN not sure what I was doing there commit_dst.clone();
-    aux_aux(
+    let target = AAA::<IdN, Idx> {
+        start: computed_range.0,
+        end: computed_range.1,
+        path: path_to_target.clone(),
+        node: computed_range.2,
+    };
+    compute::do_tracking(
         repo_handle,
         src_tr,
         dst_tr,
-        path_to_target,
-        no_spaces_path_to_target,
         flags,
-        start,
-        end,
         &state.partial_decomps,
         &state.mappings_alone,
-        repositories,
+        &repositories,
         dst_oid,
-        target_node,
+        no_spaces_path_to_target,
+        &target,
     )
 }
 
-fn aux2(
+fn track_aux2(
     state: std::sync::Arc<crate::AppState>,
     repo_handle: &impl ConfiguredRepoTrait<
         Config = hyper_ast_cvs_git::processing::ParametrizedCommitProcessorHandle,
     >,
     src_oid: hyper_ast_cvs_git::git::Oid,
     dst_oid: hyper_ast_cvs_git::git::Oid,
-    path: &[usize],
+    path: &[Idx],
     flags: &Flags,
-) -> MappingResult {
+) -> MappingResult<IdN, Idx> {
     let repositories = state.repositories.read().unwrap();
     let commit_src = repositories
         .get_commit(repo_handle.config(), &src_oid)
@@ -943,7 +1092,7 @@ fn aux2(
 
     let path_to_target: Vec<_> = path.iter().map(|x| *x as u16).collect();
     dbg!(&path_to_target);
-    let (pos, target_node, no_spaces_path_to_target) = if false {
+    let (pos, target_node, no_spaces_path_to_target): _ = if false {
         // NOTE trying stuff
         // TODO use this version
         use hyper_ast::position;
@@ -968,1292 +1117,27 @@ fn aux2(
     } else {
         compute_position_with_no_spaces(src_tr, &mut path_to_target.iter().map(|x| *x), stores)
     };
-    dbg!(&path_to_target, &no_spaces_path_to_target);
+    // dbg!(&path_to_target, &no_spaces_path_to_target);
     let range = pos.range();
-    let dst_oid = dst_oid; // WARN not sure what I was doing there commit_dst.clone();
-    aux_aux(
+    let target = AAA::<IdN, Idx> {
+        start: range.start,
+        end: range.end,
+        path: path_to_target.clone(),
+        node: target_node,
+    };
+    compute::do_tracking(
         repo_handle,
         src_tr,
         dst_tr,
-        path_to_target,
-        no_spaces_path_to_target,
         flags,
-        range.start,
-        range.end,
         &state.partial_decomps,
         &state.mappings_alone,
-        repositories,
+        &repositories,
         dst_oid,
-        target_node,
+        no_spaces_path_to_target,
+        &target,
     )
 }
-
-fn aux_aux(
-    repo_handle: &impl ConfiguredRepoTrait,
-    src_tr: NodeIdentifier,
-    dst_tr: NodeIdentifier,
-    path_to_target: Vec<u16>,
-    no_spaces_path_to_target: Vec<u16>,
-    flags: &Flags,
-    start: usize,
-    end: usize,
-    partial_decomps: &PartialDecompCache,
-    mappings_alone: &MappingAloneCache,
-    repositories: std::sync::RwLockReadGuard<multi_preprocessed::PreProcessedRepositories>,
-    dst_oid: hyper_ast_cvs_git::git::Oid,
-    target_node: NodeIdentifier,
-) -> MappingResult {
-    let with_spaces_stores = &repositories.processor.main_stores;
-    let stores = &no_space::as_nospaces(with_spaces_stores);
-    let node_store = &stores.node_store;
-    // NOTE: persists mappings, could also easily persist diffs,
-    // but some compression on mappins could help
-    // such as, not storing the decompression arenas
-    // or encoding mappings more efficiently considering that most slices could simply by represented as ranges (ie. mapped identical subtrees)
-    // let mapper = lazy_mapping(repos, &mut state.mappings, src_tr, dst_tr);
-
-    dbg!(src_tr, dst_tr);
-    if src_tr == dst_tr {
-        let src_size = stores.node_store.resolve(src_tr).size();
-        let dst_size = stores.node_store.resolve(dst_tr).size();
-        let nodes = src_size + dst_size;
-        let (pos, path_ids) = compute_position_and_nodes(
-            dst_tr,
-            &mut path_to_target.iter().copied(),
-            with_spaces_stores,
-        );
-        dbg!();
-        let range = pos.range();
-        let matches = vec![PieceOfCode {
-            user: repo_handle.spec().user.clone(),
-            name: repo_handle.spec().name.clone(),
-            commit: dst_oid.to_string(),
-            file: pos.file().to_str().unwrap().to_string(),
-            start: range.start,
-            end: range.end,
-            path: path_to_target.iter().map(|x| *x as usize).collect(),
-            path_ids: path_ids.clone(),
-        }];
-        let src = LocalPieceOfCode {
-            file: pos.file().to_string_lossy().to_string(),
-            start,
-            end,
-            path: path_to_target.iter().map(|x| *x as usize).collect(),
-            path_ids,
-        };
-        if flags.some() {
-            return MappingResult::Skipped {
-                nodes,
-                src,
-                next: matches,
-            };
-        } else {
-            return MappingResult::Direct { src, matches };
-        }
-    }
-    let pair = get_pair_simp(partial_decomps, stores, &src_tr, &dst_tr);
-
-    if flags.some() {
-        dbg!();
-
-        let mapped = {
-            let mappings_cache = mappings_alone;
-            let hyperast = stores;
-            let src = &src_tr;
-            let dst = &dst_tr;
-            let (src_arena, dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
-            matching::top_down(hyperast, src_arena, dst_arena)
-        };
-        let (mapper_src_arena, mapper_dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
-        let mapper_mappings = &mapped;
-        let mut curr = mapper_src_arena.root();
-        let mut path = &no_spaces_path_to_target[..];
-        let flags: EnumSet<_> = flags.into();
-        loop {
-            dbg!(path);
-            let dsts = mapper_mappings.get_dsts(&curr);
-            let curr_flags = FlagsE::Upd | FlagsE::Child | FlagsE::SimChild; //  | FlagsE::ExactChild
-            let parent_flags = curr_flags | FlagsE::Parent | FlagsE::SimParent; //  | FlagsE::ExactParent
-            if dsts.is_empty() {
-                // continue through path_to_target
-                dbg!(curr);
-            } else if path.len() == 0 {
-                // need to check curr node flags
-                if flags.is_subset(curr_flags) {
-                    // only trigger on curr and children changed
-
-                    let src_size = stores.node_store.resolve(src_tr).size();
-                    let dst_size = stores.node_store.resolve(dst_tr).size();
-                    let nodes = src_size + dst_size;
-                    let nodes = 500_000;
-
-                    return MappingResult::Skipped {
-                        nodes,
-                        src: {
-                            let (pos, path_ids) = compute_position_and_nodes(
-                                src_tr,
-                                &mut path_to_target.iter().copied(),
-                                with_spaces_stores,
-                            );
-
-                            LocalPieceOfCode {
-                                file: pos.file().to_string_lossy().to_string(),
-                                start,
-                                end,
-                                path: path_to_target.iter().map(|x| *x as usize).collect(),
-                                path_ids,
-                            }
-                        },
-                        next: dsts
-                            .iter()
-                            .map(|x| {
-                                let path_dst = mapper_dst_arena.path(&mapper_dst_arena.root(), x);
-                                let (path_dst,) = path_with_spaces(
-                                    dst_tr,
-                                    &mut path_dst.iter().copied(),
-                                    &repositories.processor.main_stores,
-                                );
-                                let (pos, path_ids) = compute_position_and_nodes(
-                                    dst_tr,
-                                    &mut path_dst.iter().copied(),
-                                    with_spaces_stores,
-                                );
-                                let range = pos.range();
-                                PieceOfCode {
-                                    user: repo_handle.spec().user.clone(),
-                                    name: repo_handle.spec().name.clone(),
-                                    commit: dst_oid.to_string(),
-                                    file: pos.file().to_str().unwrap().to_string(),
-                                    start: range.start,
-                                    end: range.end,
-                                    path: path_dst.iter().map(|x| *x as usize).collect(),
-                                    path_ids,
-                                }
-                            })
-                            .collect(),
-                    };
-                }
-                // also the type of src and dsts
-                // also check it file path changed
-                // can we test if parent changed ? at least we can ckeck some attributes
-            } else if path.len() == 1 {
-                // need to check parent node flags
-                if flags.is_subset(parent_flags) {
-                    // only trigger on parent, curr and children changed
-                    let src_size = stores.node_store.resolve(src_tr).size();
-                    let dst_size = stores.node_store.resolve(dst_tr).size();
-                    let nodes = src_size + dst_size;
-                    let nodes = 500_000;
-                    return MappingResult::Skipped {
-                        nodes,
-                        src: {
-                            let (pos, path_ids) = compute_position_and_nodes(
-                                src_tr,
-                                &mut path_to_target.iter().copied(),
-                                with_spaces_stores,
-                            );
-
-                            LocalPieceOfCode {
-                                file: pos.file().to_string_lossy().to_string(),
-                                start,
-                                end,
-                                path: path_to_target.iter().map(|x| *x as usize).collect(),
-                                path_ids,
-                            }
-                        },
-                        next: dsts
-                            .iter()
-                            .map(|x| {
-                                let mut path_dst =
-                                    mapper_dst_arena.path(&mapper_dst_arena.root(), x);
-                                path_dst.extend(path); // WARN with similarity it might not be possible to simply concat path...
-                                let (path_dst,) = path_with_spaces(
-                                    dst_tr,
-                                    &mut path_dst.iter().copied(),
-                                    &repositories.processor.main_stores,
-                                );
-                                let (pos, path_ids) = compute_position_and_nodes(
-                                    dst_tr,
-                                    &mut path_dst.iter().copied(),
-                                    with_spaces_stores,
-                                );
-                                let range = pos.range();
-                                PieceOfCode {
-                                    user: repo_handle.spec().user.clone(),
-                                    name: repo_handle.spec().name.clone(),
-                                    commit: dst_oid.to_string(),
-                                    file: pos.file().to_str().unwrap().to_string(),
-                                    start: range.start,
-                                    end: range.end,
-                                    path: path_dst.iter().map(|x| *x as usize).collect(),
-                                    path_ids,
-                                }
-                            })
-                            .collect(),
-                    };
-                }
-                // also the type of src and dsts
-                // also check if file path changed
-                // can we test if parent changed ? at least we can ckeck some attributes
-            } else {
-                // need to check flags, the type of src and dsts
-                if flags.is_subset(parent_flags) {
-                    // only trigger on parent, curr and children changed
-                    let src_size = stores.node_store.resolve(src_tr).size();
-                    let dst_size = stores.node_store.resolve(dst_tr).size();
-                    let nodes = src_size + dst_size;
-                    let nodes = 500_000;
-                    return MappingResult::Skipped {
-                        nodes,
-                        src: {
-                            let (pos, path_ids) = compute_position_and_nodes(
-                                src_tr,
-                                &mut path_to_target.iter().copied(),
-                                with_spaces_stores,
-                            );
-
-                            LocalPieceOfCode {
-                                file: pos.file().to_string_lossy().to_string(),
-                                start,
-                                end,
-                                path: path_to_target.iter().map(|x| *x as usize).collect(),
-                                path_ids,
-                            }
-                        },
-                        next: dsts
-                            .iter()
-                            .map(|x| {
-                                let mut path_dst =
-                                    mapper_dst_arena.path(&mapper_dst_arena.root(), x);
-                                path_dst.extend(path); // WARN with similarity it might not be possible to simply concat path...
-                                let (path_dst,) = path_with_spaces(
-                                    dst_tr,
-                                    &mut path_dst.iter().copied(),
-                                    &repositories.processor.main_stores,
-                                );
-                                let (pos, path_ids) = compute_position_and_nodes(
-                                    dst_tr,
-                                    &mut path_dst.iter().copied(),
-                                    with_spaces_stores,
-                                );
-                                let range = pos.range();
-                                PieceOfCode {
-                                    user: repo_handle.spec().user.clone(),
-                                    name: repo_handle.spec().name.clone(),
-                                    commit: dst_oid.to_string(),
-                                    file: pos.file().to_str().unwrap().to_string(),
-                                    start: range.start,
-                                    end: range.end,
-                                    path: path_dst.iter().map(|x| *x as usize).collect(),
-                                    path_ids,
-                                }
-                            })
-                            .collect(),
-                    };
-                }
-                // also check if file path changed
-                // can we test if parent changed ? at least we can ckeck some attributes
-            }
-
-            let Some(i) = path.get(0) else {
-                break;
-            };
-            path = &path[1..];
-            let cs = mapper_src_arena.decompress_children(node_store, &curr);
-            if cs.is_empty() {
-                break;
-            }
-            curr = cs[*i as usize];
-        }
-    }
-
-    let mapped = {
-        let mappings_cache = mappings_alone;
-        use hyper_diff::matchers::mapping_store::MappingStore;
-        use hyper_diff::matchers::mapping_store::VecStore;
-        let hyperast = stores;
-        use hyper_diff::matchers::Mapping;
-
-        dbg!();
-        match mappings_cache.entry((src_tr, dst_tr)) {
-            dashmap::mapref::entry::Entry::Occupied(entry) => entry.into_ref().downgrade(),
-            dashmap::mapref::entry::Entry::Vacant(entry) => {
-                let mappings = VecStore::default();
-                let (src_arena, dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
-                dbg!(src_arena.len());
-                dbg!(dst_arena.len());
-                let src_size = stores.node_store.resolve(src_tr).size();
-                let dst_size = stores.node_store.resolve(dst_tr).size();
-                dbg!(src_size);
-                dbg!(dst_size);
-                let mut mapper = Mapper {
-                    hyperast,
-                    mapping: Mapping {
-                        src_arena,
-                        dst_arena,
-                        mappings,
-                    },
-                };
-                dbg!();
-                dbg!(mapper.mapping.src_arena.len());
-                dbg!(mapper.mapping.dst_arena.len());
-                mapper.mapping.mappings.topit(
-                    mapper.mapping.src_arena.len(),
-                    mapper.mapping.dst_arena.len(),
-                );
-                dbg!();
-
-                let vec_store = matching::full2(hyperast, mapper);
-
-                dbg!();
-                entry
-                    .insert((crate::MappingStage::Bottomup, vec_store))
-                    .downgrade()
-            }
-        }
-    };
-    let (mapper_src_arena, mapper_dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
-    let mapper_mappings = &mapped.1;
-    let root = mapper_src_arena.root();
-    let mapping_target =
-        mapper_src_arena.child_decompressed(node_store, &root, &no_spaces_path_to_target);
-
-    let mut matches = vec![];
-    if let Some(mapped) = mapper_mappings.get_dst(&mapping_target) {
-        let mapped = mapper_dst_arena.decompress_to(node_store, &mapped);
-        let path = mapper_dst_arena.path(&mapper_dst_arena.root(), &mapped);
-        let mut path_ids = vec![mapper_dst_arena.original(&mapped)];
-        mapper_dst_arena
-            .parents(mapped)
-            .map(|i| mapper_dst_arena.original(&i))
-            .collect_into(&mut path_ids);
-        path_ids.pop();
-        assert_eq!(path.len(), path_ids.len());
-        let (path,) = path_with_spaces(
-            dst_tr,
-            &mut path.iter().copied(),
-            &repositories.processor.main_stores,
-        );
-        let (pos, mapped_node) =
-            compute_position(dst_tr, &mut path.iter().copied(), with_spaces_stores);
-        dbg!(&pos);
-        dbg!(&mapped_node);
-        let mut flagged = false;
-        let mut triggered = false;
-        if flags.exact_child {
-            flagged = true;
-            dbg!();
-            triggered |= target_node != mapped_node;
-        }
-        if flags.child || flags.sim_child {
-            flagged = true;
-            dbg!();
-
-            let target_node = stores.node_store.resolve(target_node);
-            let mapped_node = stores.node_store.resolve(mapped_node);
-            if flags.sim_child {
-                triggered |= target_node.hash(&types::HashKind::structural())
-                    != mapped_node.hash(&types::HashKind::structural());
-            } else {
-                triggered |= target_node.hash(&types::HashKind::label())
-                    != mapped_node.hash(&types::HashKind::label());
-            }
-        }
-        if flags.upd {
-            flagged = true;
-            dbg!();
-            // TODO need role name
-            // let target_ident = child_by_type(stores, target_node, &Type::Identifier);
-            // let mapped_ident = child_by_type(stores, mapped_node, &Type::Identifier);
-            // if let (Some(target_ident), Some(mapped_ident)) = (target_ident, mapped_ident) {
-            //     let target_node = stores.node_store.resolve(target_ident.0);
-            //     let target_ident = target_node.try_get_label();
-            //     let mapped_node = stores.node_store.resolve(mapped_ident.0);
-            //     let mapped_ident = mapped_node.try_get_label();
-            //     triggered |= target_ident != mapped_ident;
-            // }
-        }
-        if flags.parent {
-            flagged = true;
-            dbg!();
-
-            let target_parent = mapper_src_arena.parent(&mapping_target);
-            let target_parent = target_parent.map(|x| mapper_src_arena.original(&x));
-            let mapped_parent = mapper_dst_arena.parent(&mapped);
-            let mapped_parent = mapped_parent.map(|x| mapper_dst_arena.original(&x));
-            triggered |= target_parent != mapped_parent;
-        }
-        // if flags.meth {
-        //     flagged = true;
-        //     dbg!();
-        // }
-        // if flags.typ {
-        //     flagged = true;
-        //     dbg!();
-        // }
-        // if flags.top {
-        //     flagged = true;
-        //     dbg!();
-        // }
-        // if flags.file {
-        //     flagged = true;
-        //     dbg!();
-        // }
-        // if flags.pack {
-        //     flagged = true;
-        //     dbg!();
-        // }
-        // TODO add flags for artefacts (tests, prod code, build, lang, misc)
-        // TODO add flags for similarity comps
-        let range = pos.range();
-        matches.push(PieceOfCode {
-            user: repo_handle.spec().user.clone(),
-            name: repo_handle.spec().name.clone(),
-            commit: dst_oid.to_string(),
-            file: pos.file().to_str().unwrap().to_string(),
-            start: range.start,
-            end: range.end,
-            path: path.iter().map(|x| *x as usize).collect(),
-            path_ids: path_ids.clone(),
-        });
-        if flagged && !triggered {
-            use hyper_ast::types::WithStats;
-            let src_size = stores.node_store.resolve(src_tr).size();
-            let dst_size = stores.node_store.resolve(dst_tr).size();
-            let nodes = src_size + dst_size;
-            return MappingResult::Skipped {
-                nodes,
-                src: {
-                    let (pos, path_ids) = compute_position_and_nodes(
-                        src_tr,
-                        &mut path_to_target.iter().copied(),
-                        with_spaces_stores,
-                    );
-
-                    LocalPieceOfCode {
-                        file: pos.file().to_string_lossy().to_string(),
-                        start,
-                        end,
-                        path: path_to_target.iter().map(|x| *x as usize).collect(),
-                        path_ids,
-                    }
-                },
-                next: matches,
-            };
-        }
-        let path = path_to_target.iter().map(|x| *x as usize).collect();
-        let (target_pos, target_path_ids) = compute_position_and_nodes(
-            src_tr,
-            &mut path_to_target.iter().copied(),
-            with_spaces_stores,
-        );
-        return MappingResult::Direct {
-            src: LocalPieceOfCode {
-                file: target_pos.file().to_string_lossy().to_string(),
-                start,
-                end,
-                path,
-                path_ids: target_path_ids,
-            },
-            matches,
-        };
-    }
-
-    for parent_target in mapper_src_arena.parents(mapping_target) {
-        if let Some(mapped_parent) = mapper_mappings.get_dst(&parent_target) {
-            let mapped_parent = mapper_dst_arena.decompress_to(node_store, &mapped_parent);
-            let path = mapper_dst_arena.path(&mapper_dst_arena.root(), &mapped_parent);
-            let mut path_ids = vec![mapper_dst_arena.original(&mapped_parent)];
-            mapper_dst_arena
-                .parents(mapped_parent)
-                .map(|i| mapper_dst_arena.original(&i))
-                .collect_into(&mut path_ids);
-            path_ids.pop();
-            assert_eq!(path.len(), path_ids.len());
-            let (path,) = path_with_spaces(
-                dst_tr,
-                &mut path.iter().copied(),
-                &repositories.processor.main_stores,
-            );
-            let (pos, mapped_node) =
-                compute_position(dst_tr, &mut path.iter().copied(), with_spaces_stores);
-            dbg!(&pos);
-            dbg!(&mapped_node);
-            let range = pos.range();
-            let fallback = PieceOfCode {
-                user: repo_handle.spec().user.clone(),
-                name: repo_handle.spec().name.clone(),
-                commit: dst_oid.to_string(),
-                file: pos.file().to_str().unwrap().to_string(),
-                start: range.start,
-                end: range.end,
-                path: path.iter().map(|x| *x as usize).collect(),
-                path_ids: path_ids.clone(),
-            };
-
-            let src = {
-                let path = path_to_target.iter().map(|x| *x as usize).collect();
-                let (target_pos, target_path_ids) = compute_position_and_nodes(
-                    src_tr,
-                    &mut path_to_target.iter().copied(),
-                    with_spaces_stores,
-                );
-                LocalPieceOfCode {
-                    file: target_pos.file().to_string_lossy().to_string(),
-                    start,
-                    end,
-                    path,
-                    path_ids: target_path_ids,
-                }
-            };
-            return MappingResult::Missing { src, fallback };
-        };
-    }
-    let path = path_to_target.iter().map(|x| *x as usize).collect();
-    let (target_pos, target_path_ids) = compute_position_and_nodes(
-        src_tr,
-        &mut path_to_target.iter().copied(),
-        with_spaces_stores,
-    );
-    // TODO what should be done if there is no match ?
-    MappingResult::Direct {
-        src: LocalPieceOfCode {
-            file: target_pos.file().to_string_lossy().to_string(),
-            start,
-            end,
-            path,
-            path_ids: target_path_ids,
-        },
-        matches,
-    }
-}
-
-// fn diff<'a>(
-//     repositories: &'a multi_preprocessed::PreProcessedRepositories,
-//     mappings: &'a mut crate::MappingCache,
-//     src_tr: NodeIdentifier,
-//     dst_tr: NodeIdentifier,
-// ) -> &'a hyper_diff::matchers::Mapping<
-//     hyper_diff::decompressed_tree_store::CompletePostOrder<
-//         hyper_ast::store::nodes::legion::HashedNodeRef<'a>,
-//         u32,
-//     >,
-//     hyper_diff::decompressed_tree_store::CompletePostOrder<
-//         hyper_ast::store::nodes::legion::HashedNodeRef<'a>,
-//         u32,
-//     >,
-//     hyper_diff::matchers::mapping_store::VecStore<u32>,
-// > {
-//     use hyper_diff::decompressed_tree_store::CompletePostOrder;
-//     let mapped = mappings.entry((src_tr, dst_tr)).or_insert_with(|| {
-//         hyper_diff::algorithms::gumtree_lazy::diff(
-//             &repositories.processor.main_stores,
-//             &src_tr,
-//             &dst_tr,
-//         )
-//         .mapper
-//         .persist()
-//     });
-//     unsafe { Mapper::<_,CompletePostOrder<_,_>,CompletePostOrder<_,_>,_>::unpersist(&repositories.processor.main_stores, &*mapped) }
-// }
-
-// WARN lazy subtrees are not complete
-fn lazy_mapping<'a>(
-    repositories: &'a multi_preprocessed::PreProcessedRepositories,
-    mappings: &'a crate::MappingCache,
-    src_tr: NodeIdentifier,
-    dst_tr: NodeIdentifier,
-) -> dashmap::mapref::one::RefMut<
-    'a,
-    (NodeIdentifier, NodeIdentifier),
-    hyper_diff::matchers::Mapping<
-        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
-            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
-            u32,
-        >,
-        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
-            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
-            u32,
-        >,
-        hyper_diff::matchers::mapping_store::VecStore<u32>,
-    >,
-> {
-    use hyper_ast::types::HyperAST;
-    use hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder;
-    use hyper_diff::matchers::heuristic::gt::{
-        lazy2_greedy_bottom_up_matcher::GreedyBottomUpMatcher,
-        lazy2_greedy_subtree_matcher::LazyGreedySubtreeMatcher,
-    };
-    use hyper_diff::matchers::mapping_store::DefaultMultiMappingStore;
-    use hyper_diff::matchers::mapping_store::MappingStore;
-    use hyper_diff::matchers::mapping_store::VecStore;
-    let mapped = mappings.entry((src_tr, dst_tr)).or_insert_with(|| {
-        let hyperast = &repositories.processor.main_stores;
-        let src = &src_tr;
-        let dst = &dst_tr;
-        let now = Instant::now();
-        let mapper: Mapper<_, LazyPostOrder<_, u32>, LazyPostOrder<_, u32>, VecStore<_>> =
-            hyperast.decompress_pair(src, dst).into();
-        let subtree_prepare_t = now.elapsed().as_secs_f64();
-        let now = Instant::now();
-        let mapper =
-            LazyGreedySubtreeMatcher::<_, _, _, _>::match_it::<DefaultMultiMappingStore<_>>(mapper);
-        let subtree_matcher_t = now.elapsed().as_secs_f64();
-        let subtree_mappings_s = mapper.mappings().len();
-        dbg!(&subtree_matcher_t, &subtree_mappings_s);
-        let bottomup_prepare_t = 0.;
-        let now = Instant::now();
-        let mapper = GreedyBottomUpMatcher::<_, _, _, _, VecStore<_>>::match_it(mapper);
-        dbg!(&now.elapsed().as_secs_f64());
-        let bottomup_matcher_t = now.elapsed().as_secs_f64();
-        let bottomup_mappings_s = mapper.mappings().len();
-        dbg!(&bottomup_matcher_t, &bottomup_mappings_s);
-        // let now = Instant::now();
-
-        // NOTE could also have completed trees
-        // let node_store = hyperast.node_store();
-        // let mapper = mapper.map(
-        //     |src_arena| CompletePostOrder::from(src_arena.complete(node_store)),
-        //     |dst_arena| {
-        //         let complete = CompletePostOrder::from(dst_arena.complete(node_store));
-        //         SimpleBfsMapper::from(node_store, complete)
-        //     },
-        // );
-
-        // NOTE we do not use edit scripts here
-        // let prepare_gen_t = now.elapsed().as_secs_f64();
-        // let now = Instant::now();
-        // let actions = ScriptGenerator::compute_actions(mapper.hyperast, &mapper.mapping).ok();
-        // let gen_t = now.elapsed().as_secs_f64();
-        // dbg!(gen_t);
-        // let mapper = mapper.map(|x| x, |dst_arena| dst_arena.back);
-        Mapper::<_, LazyPostOrder<_, _>, LazyPostOrder<_, _>, _>::persist(mapper)
-    });
-    pub unsafe fn unpersist<'a>(
-        _hyperast: &'a SimpleStores<TStore>,
-        p: dashmap::mapref::one::RefMut<
-            'a,
-            (NodeIdentifier, NodeIdentifier),
-            hyper_diff::matchers::Mapping<
-                LazyPostOrder<
-                    hyper_diff::decompressed_tree_store::PersistedNode<NodeIdentifier>,
-                    u32,
-                >,
-                LazyPostOrder<
-                    hyper_diff::decompressed_tree_store::PersistedNode<NodeIdentifier>,
-                    u32,
-                >,
-                VecStore<u32>,
-            >,
-        >,
-    ) -> dashmap::mapref::one::RefMut<
-        'a,
-        (NodeIdentifier, NodeIdentifier),
-        hyper_diff::matchers::Mapping<
-            LazyPostOrder<HashedNodeRef<'a, NodeIdentifier>, u32>,
-            LazyPostOrder<HashedNodeRef<'a, NodeIdentifier>, u32>,
-            VecStore<u32>,
-        >,
-    > {
-        unsafe { std::mem::transmute(p) }
-    }
-    unsafe { unpersist(&repositories.processor.main_stores, mapped) }
-}
-
-struct RRR<'a>(
-    dashmap::mapref::one::Ref<
-        'a,
-        (NodeIdentifier, NodeIdentifier),
-        (
-            crate::MappingStage,
-            hyper_diff::matchers::mapping_store::VecStore<u32>,
-        ),
-    >,
-);
-
-mod my_dash {
-    use std::{
-        cell::UnsafeCell,
-        collections::hash_map::RandomState,
-        fmt::Debug,
-        hash::{BuildHasher, Hash},
-    };
-
-    use dashmap::{DashMap, RwLockWriteGuard, SharedValue};
-    use hashbrown::HashMap;
-
-    // pub fn entries<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone>(
-    //     map: DashMap<K, V, S>,
-    //     key1: K,
-    //     key2: K,
-    // ) -> Entry<'a, K, V, S> {
-    //     let hash = map.hash_usize(&key1);
-
-    //     let idx = map.determine_shard(hash);
-
-    //     let shard: RwLockWriteGuard<HashMap<K, SharedValue<V>, S>> = unsafe {
-    //         debug_assert!(idx < map.shards().len());
-
-    //         map.shards().get_unchecked(idx).write()
-    //     };
-
-    //     #[repr(transparent)]
-    //     struct MySharedValue<T> {
-    //         value: UnsafeCell<T>,
-    //     }
-
-    //     impl<T> MySharedValue<T> {
-    //         /// Get a mutable raw pointer to the underlying value
-    //         fn as_ptr(&self) -> *mut T {
-    //             self.value.get()
-    //         }
-    //     }
-    //     // SAFETY: Sharded and UnsafeCell are transparent wrappers of V
-    //     let shard: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard) };
-    //     if let Some((kptr, vptr)) = shard.get_key_value(&key1) {
-    //         unsafe {
-    //             let kptr: *const K = kptr;
-    //             // SAFETY: same memory layout because transparent and same fields
-    //             let vptr: &MySharedValue<V> = std::mem::transmute(&vptr);
-    //             let vptr: *mut V = vptr.as_ptr();
-    //             Entry::Occupied(OccupiedEntry::new(shard, key1, (kptr, vptr)))
-    //         }
-    //     } else {
-    //         unsafe {
-    //             // SAFETY: same memory layout because transparent and same fields
-    //             let shard: RwLockWriteGuard<HashMap<K, V, S>> = std::mem::transmute(shard);
-    //             Entry::Vacant(VacantEntry::new(shard, key1))
-    //         }
-    //     }
-    pub fn entries<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone>(
-        map: &'a DashMap<K, V, S>,
-        key1: K,
-        key2: K,
-    ) -> Entry<'a, K, V, S> {
-        assert!(key1 != key2, "keys should be different");
-        let hash1 = map.hash_usize(&key1);
-        let idx1 = map.determine_shard(hash1);
-        let hash2 = map.hash_usize(&key2);
-        let idx2 = map.determine_shard(hash2);
-
-        if idx1 == idx2 {
-            let shard = unsafe {
-                debug_assert!(idx1 < map.shards().len());
-                debug_assert!(idx2 < map.shards().len());
-                map.shards().get_unchecked(idx1).write()
-            };
-            // SAFETY: Sharded and UnsafeCell are transparent wrappers of V
-            let shard: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard) };
-            let elem1 = shard
-                .get_key_value(&key1)
-                .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
-            let elem2 = shard
-                .get_key_value(&key2)
-                .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
-            Entry {
-                shard1: shard,
-                shard2: None,
-                key1,
-                key2,
-                elem1,
-                elem2,
-            }
-        } else {
-            let (shard1, shard2) = unsafe {
-                debug_assert!(idx1 < map.shards().len());
-                debug_assert!(idx2 < map.shards().len());
-                (
-                    map.shards().get_unchecked(idx1).write(),
-                    map.shards().get_unchecked(idx2).write(),
-                )
-            };
-            let shard1: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard1) };
-            let shard2: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard2) };
-            let elem1 = shard1
-                .get_key_value(&key1)
-                .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
-            let elem2 = shard2
-                .get_key_value(&key2)
-                .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
-            Entry {
-                shard1: shard1,
-                shard2: Some(shard2),
-                key1,
-                key2,
-                elem1,
-                elem2,
-            }
-        }
-    }
-
-    unsafe fn as_ptr<'a, K: 'a + Eq + Hash, V: 'a>(kptr1: &K, vptr1: &V) -> (*const K, *mut V) {
-        let kptr1: *const K = kptr1;
-        // SAFETY: same memory layout because transparent and same fields
-        let vptr1: &MySharedValue<V> = std::mem::transmute(&vptr1);
-        let vptr1: *mut V = vptr1.as_ptr();
-        (kptr1, vptr1)
-    }
-
-    pub(super) unsafe fn shard_as_ptr<'a, V: 'a>(vptr1: &SharedValue<V>) -> *mut V {
-        // SAFETY: same memory layout because transparent and same fields
-        let vptr1: &MySharedValue<V> = std::mem::transmute(&vptr1);
-        let vptr1: *mut V = vptr1.as_ptr();
-        vptr1
-    }
-
-    pub(super) unsafe fn shard_as_ptr2<'a, V: 'a>(vptr1: &V) -> *mut V {
-        // SAFETY: same memory layout because transparent and same fields
-        let vptr1: &MySharedValue<V> = std::mem::transmute(&vptr1);
-        let vptr1: *mut V = vptr1.as_ptr();
-        vptr1
-    }
-
-    #[repr(transparent)]
-    struct MySharedValue<T> {
-        value: UnsafeCell<T>,
-    }
-
-    impl<T> MySharedValue<T> {
-        /// Get a mutable raw pointer to the underlying value
-        fn as_ptr(&self) -> *mut T {
-            self.value.get()
-        }
-    }
-    pub struct Entry<'a, K, V, S = RandomState> {
-        shard1: RwLockWriteGuard<'a, HashMap<K, V, S>>,
-        shard2: Option<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
-        elem1: Option<(*const K, *mut V)>,
-        elem2: Option<(*const K, *mut V)>,
-        key1: K,
-        key2: K,
-    }
-    unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Send for Entry<'a, K, V, S> {}
-    unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Sync for Entry<'a, K, V, S> {}
-
-    impl<'a, K: Clone + Eq + Hash + Debug, V: Debug, S: BuildHasher> Entry<'a, K, V, S> {
-        pub fn or_insert_with(
-            self,
-            value: impl FnOnce((Option<()>, Option<()>)) -> (Option<V>, Option<V>),
-        ) -> RefMut<'a, K, V, S> {
-            match self {
-                Entry {
-                    shard1,
-                    shard2,
-                    elem1: Some((k1, v1)),
-                    elem2: Some((k2, v2)),
-                    ..
-                } => {
-                    dbg!(v1);
-                    dbg!(v2);
-                    RefMut {
-                        guard1: shard1,
-                        guard2: shard2,
-                        k1,
-                        k2,
-                        v1,
-                        v2,
-                    }
-                }
-                Entry {
-                    mut shard1,
-                    shard2: None,
-                    elem1,
-                    elem2,
-                    key1,
-                    key2,
-                } => {
-                    let (r1, r2) = value((elem1.as_ref().map(|_| ()), elem2.as_ref().map(|_| ())));
-                    let k1 = key1.clone();
-                    let k2 = key2.clone();
-                    if elem1.is_none() {
-                        let value = r1.expect("some value");
-                        let key = key1;
-                        let shard = &mut shard1;
-                        insert2_p1(key, shard, value)
-                    }
-                    if elem2.is_none() {
-                        let value = r2.expect("some value");
-                        let key = key2;
-                        let shard = &mut shard1;
-                        insert2_p1(key, shard, value)
-                    }
-                    let (k1, v1) = elem1.unwrap_or_else(|| {
-                        let shard = &mut shard1;
-                        insert2_p2(&k1, shard)
-                    });
-                    let (k2, v2) = elem2.unwrap_or_else(|| {
-                        let shard = &mut shard1;
-                        insert2_p2(&k2, shard)
-                    });
-                    dbg!(v1);
-                    dbg!(v2);
-                    RefMut {
-                        guard1: shard1,
-                        guard2: None,
-                        k1,
-                        k2,
-                        v1,
-                        v2,
-                    }
-                }
-                Entry {
-                    mut shard1,
-                    shard2: Some(mut shard2),
-                    elem1,
-                    elem2,
-                    key1,
-                    key2,
-                } => {
-                    let (r1, r2) = value((elem1.as_ref().map(|_| ()), elem2.as_ref().map(|_| ())));
-                    // let (k1, v1) = elem1.unwrap_or_else(|| {
-                    //     let value = r1.expect("some value");
-                    //     let key = key1;
-                    //     let shard = &mut shard1;
-                    //     println!("{:p}", shard);
-                    //     println!("{:p}", &key);
-                    //     println!("{}", shard.hasher().hash_one(&key));
-                    //     insert2(key, shard, value)
-                    // });
-                    // let (k2, v2) = elem2.unwrap_or_else(|| {
-                    //     let value = r2.expect("some value");
-                    //     let key = key2;
-                    //     let shard = &mut shard2;
-                    //     insert2(key, shard, value)
-                    // });
-                    let k1 = key1.clone();
-                    let k2 = key2.clone();
-                    dbg!(&k1);
-                    dbg!(&k2);
-                    println!("{:p}", &k1);
-                    println!("{:p}", &k2);
-                    println!("{:p}", &r1);
-                    println!("{:p}", &r2);
-                    if elem1.is_none() {
-                        let value = r1.expect("some value");
-                        dbg!(&value);
-                        println!("{:p}", &value);
-                        let key = key1;
-                        let shard = &mut shard1;
-                        insert2_p1_shard(key, shard, value)
-                    }
-                    if elem2.is_none() {
-                        let value = r2.expect("some value");
-                        dbg!(&value);
-                        println!("{:p}", &value);
-                        let key = key2;
-                        let shard = &mut shard2;
-                        insert2_p1(key, shard, value)
-                    }
-                    let (k1, v1) = elem1.unwrap_or_else(|| {
-                        let shard = &mut shard1;
-                        dbg!(shard.hasher().hash_one(&k1));
-                        let shard: &mut RwLockWriteGuard<HashMap<K, SharedValue<V>>> =
-                            unsafe { std::mem::transmute(shard) };
-                        insert2_p2_shard(&k1, shard)
-                    });
-                    let (k2, v2) = elem2.unwrap_or_else(|| {
-                        let shard = &mut shard2;
-                        insert2_p2(&k2, shard)
-                    });
-                    println!("{:p}", &shard1);
-                    dbg!(shard1.len());
-                    println!("{:p}", &shard2);
-                    dbg!(shard2.len());
-                    dbg!(v1);
-                    dbg!(v2);
-                    RefMut {
-                        guard1: shard1,
-                        guard2: Some(shard2),
-                        k1,
-                        k2,
-                        v1,
-                        v2,
-                    }
-                }
-            }
-        }
-    }
-
-    fn insert2<'a, K: Eq + Hash, V, S: BuildHasher>(
-        key: K,
-        shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
-        value: V,
-    ) -> (*const K, *mut V) {
-        let c = unsafe { std::ptr::read(&key) };
-        shard.insert(key, value);
-        // let shard: &mut RwLockWriteGuard<HashMap<K, SharedValue<V>>> =
-        //     unsafe { std::mem::transmute(shard) };
-        {
-            // let shard: &'a mut RwLockWriteGuard<'a, HashMap<K, SharedValue<V>>> = shard;
-            unsafe {
-                use std::mem;
-                dbg!();
-                let (k, v) = shard.get_key_value(&c).unwrap();
-                dbg!();
-                let k = change_lifetime_const(k);
-                dbg!();
-                let v = &mut *shard_as_ptr2(v);
-                dbg!();
-                mem::forget(c);
-                dbg!();
-                (k, v)
-            }
-        }
-    }
-
-    fn insert2_p1<'a, K: Eq + Hash, V, S: BuildHasher>(
-        key: K,
-        shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
-        value: V,
-    ) {
-        println!("{:p}", &key);
-        println!("{}", shard.hasher().hash_one(&key));
-        println!("{:p}", &value);
-        shard.insert(key, value);
-    }
-
-    fn insert2_p1_shard<'a, K: Eq + Hash, V, S: BuildHasher>(
-        key: K,
-        shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
-        value: V,
-    ) {
-        println!("{:p}", &key);
-        println!("{}", shard.hasher().hash_one(&key));
-        println!("{:p}", &value);
-        // let shard: &mut RwLockWriteGuard<HashMap<K, SharedValue<V>>> =
-        //             unsafe { std::mem::transmute(shard) };
-        // let value: SharedValue<V> = SharedValue::new(value);
-        println!("{:p}", &key);
-        println!("{}", shard.hasher().hash_one(&key));
-        println!("{:p}", &value);
-        // todo!()
-        shard.insert(key, value);
-    }
-
-    fn insert2_p2<'a, K: Eq + Hash, V, S: BuildHasher>(
-        key: &K,
-        shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
-    ) -> (*const K, *mut V) {
-        unsafe {
-            use std::mem;
-            dbg!();
-            println!("{:p}", &key);
-            println!("{}", shard.hasher().hash_one(&key));
-            let (k, v) = shard.get_key_value(key).unwrap();
-            dbg!();
-            let k = change_lifetime_const(k);
-            dbg!();
-            let v = &mut *shard_as_ptr2(v);
-            dbg!();
-            (k, v)
-        }
-    }
-
-    fn insert2_p2_shard<'a, K: Eq + Hash, V, S: BuildHasher>(
-        key: &K,
-        shard: &mut RwLockWriteGuard<'a, HashMap<K, SharedValue<V>, S>>,
-    ) -> (*const K, *mut V) {
-        unsafe {
-            dbg!();
-            println!("{:p}", &key);
-            println!("{}", shard.hasher().hash_one(&key));
-            todo!();
-
-            let (k, v) = shard.get_key_value(key).unwrap();
-            dbg!();
-            let k = change_lifetime_const(k);
-            dbg!();
-            let v = &mut *shard_as_ptr(v);
-            dbg!();
-            (k, v)
-        }
-    }
-
-    fn insert<'a, K: Eq + Hash, V>(
-        key: K,
-        shard: &'a mut RwLockWriteGuard<'a, HashMap<K, SharedValue<V>>>,
-        value: SharedValue<V>,
-    ) -> (*const K, *mut V) {
-        unsafe {
-            use std::mem;
-            use std::ptr;
-            let c: K = ptr::read(&key);
-            dbg!();
-            println!("{:p}", &key);
-            println!("{}", shard.hasher().hash_one(&key));
-            println!("{:p}", &value);
-            {
-                // let shard: &mut RwLockWriteGuard<HashMap<K, V>> =
-                //     unsafe { std::mem::transmute(shard) };
-                // let value: V =
-                //     unsafe { std::mem::transmute(value) };
-                shard.insert(key, value);
-            }
-            dbg!();
-            let (k, v) = shard.get_key_value(&c).unwrap();
-            dbg!();
-            let k = change_lifetime_const(k);
-            dbg!();
-            let v = &mut *shard_as_ptr(v);
-            dbg!();
-            mem::forget(c);
-            dbg!();
-            (k, v)
-        }
-    }
-
-    /// # Safety
-    ///
-    /// Requires that you ensure the reference does not become invalid.
-    /// The object has to outlive the reference.
-    unsafe fn change_lifetime_const<'a, 'b, T>(x: &'a T) -> &'b T {
-        &*(x as *const T)
-    }
-
-    pub struct RefMut<'a, K, V, S = RandomState> {
-        guard1: RwLockWriteGuard<'a, HashMap<K, V, S>>,
-        guard2: Option<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
-        k1: *const K,
-        k2: *const K,
-        v1: *mut V,
-        v2: *mut V,
-    }
-
-    unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Send for RefMut<'a, K, V, S> {}
-    unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Sync for RefMut<'a, K, V, S> {}
-
-    impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMut<'a, K, V, S> {
-        pub fn value_mut(&mut self) -> (&mut V, &mut V) {
-            unsafe { (&mut *self.v1, &mut *self.v2) }
-        }
-    }
-}
-
-// WARN lazy subtrees are not complete
-fn lazy_subtree_mapping<'a, 'b>(
-    repositories: &'a multi_preprocessed::PreProcessedRepositories,
-    partial_comp_cache: &'a crate::PartialDecompCache,
-    src_tr: NodeIdentifier,
-    dst_tr: NodeIdentifier,
-) -> hyper_diff::matchers::Mapping<
-    dashmap::mapref::one::RefMut<
-        'a,
-        NodeIdentifier,
-        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
-            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
-            u32,
-        >,
-    >,
-    dashmap::mapref::one::RefMut<
-        'a,
-        NodeIdentifier,
-        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
-            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
-            u32,
-        >,
-    >,
-    mapping_store::MultiVecStore<u32>,
-> {
-    use hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder;
-    use hyper_diff::matchers::heuristic::gt::lazy2_greedy_subtree_matcher::LazyGreedySubtreeMatcher;
-    use hyper_diff::matchers::mapping_store::DefaultMultiMappingStore;
-    use hyper_diff::matchers::mapping_store::MappingStore;
-    use hyper_diff::matchers::mapping_store::VecStore;
-    use hyper_diff::matchers::Mapping;
-
-    let hyperast = &repositories.processor.main_stores;
-    let src = &src_tr;
-    let dst = &dst_tr;
-    let now = Instant::now();
-    assert_ne!(src, dst);
-    let (mut decompress_src, mut decompress_dst) = {
-        use hyper_ast::types::DecompressedSubtree;
-        let mut cached_decomp = |id: &NodeIdentifier| -> Option<
-            dashmap::mapref::one::RefMut<NodeIdentifier, LazyPostOrder<HashedNodeRef<'a>, u32>>,
-        > {
-            let decompress = partial_comp_cache
-                .try_entry(*id)?
-                .or_insert_with(|| unsafe {
-                    std::mem::transmute(LazyPostOrder::<_, u32>::decompress(
-                        hyperast.node_store(),
-                        id,
-                    ))
-                });
-            Some(unsafe { std::mem::transmute(decompress) })
-        };
-        loop {
-            match (cached_decomp(src), cached_decomp(dst)) {
-                (Some(decompress_src), Some(decompress_dst)) => {
-                    break (decompress_src, decompress_dst)
-                }
-                (None, None) => {
-                    dbg!();
-                }
-                _ => {
-                    dbg!(
-                        partial_comp_cache.hash_usize(src),
-                        partial_comp_cache.hash_usize(dst)
-                    );
-                    dbg!(
-                        partial_comp_cache.determine_shard(partial_comp_cache.hash_usize(src)),
-                        partial_comp_cache.determine_shard(partial_comp_cache.hash_usize(dst))
-                    );
-                }
-            }
-            sleep(Duration::from_secs(2));
-        }
-    };
-    hyperast
-        .node_store
-        .resolve(decompress_src.original(&decompress_src.root()));
-    hyperast
-        .node_store
-        .resolve(decompress_dst.original(&decompress_dst.root()));
-
-    let mappings = VecStore::default();
-    let mut mapper = Mapper {
-        hyperast,
-        mapping: Mapping {
-            src_arena: decompress_src.value_mut(),
-            dst_arena: decompress_dst.value_mut(),
-            mappings,
-        },
-    };
-    mapper.mapping.mappings.topit(
-        mapper.mapping.src_arena.len(),
-        mapper.mapping.dst_arena.len(),
-    );
-    dbg!();
-    let mm = LazyGreedySubtreeMatcher::<
-        'a,
-        SimpleStores<TStore>,
-        &mut LazyPostOrder<HashedNodeRef<'a>, u32>,
-        &mut LazyPostOrder<HashedNodeRef<'a>, u32>,
-        VecStore<_>,
-    >::compute_multi_mapping::<DefaultMultiMappingStore<_>>(&mut mapper);
-    dbg!();
-
-    hyper_diff::matchers::Mapping {
-        src_arena: decompress_src,
-        dst_arena: decompress_dst,
-        mappings: mm,
-    }
-}
-
-pub fn child_by_type<'store, HAST: HyperAST<'store, IdN = NodeIdentifier>>(
-    stores: &'store HAST,
-    d: NodeIdentifier,
-    t: &<HAST::TS as types::TypeStore<HAST::T>>::Ty,
-) -> Option<(NodeIdentifier, usize)> {
-    let n = stores.node_store().resolve(&d);
-    let s = n
-        .children()
-        .unwrap()
-        .iter_children()
-        .enumerate()
-        .find(|(_, x)| {
-            stores.resolve_type(*x).eq(t)
-        })
-        .map(|(i, x)| (*x, i));
-    s
-}
+mod compute;
+mod more;
+mod my_dash;

--- a/client/src/track.rs
+++ b/client/src/track.rs
@@ -7,12 +7,12 @@ use hyper_ast::{
         compute_position, compute_position_and_nodes, compute_position_with_no_spaces,
         compute_range, path_with_spaces,
         position_accessors::{self, SolvedPosition, WithOffsets, WithPreOrderPath},
-        resolve_range, PrimInt,
+        resolve_range,
     },
     store::{defaults::NodeIdentifier, nodes::legion::HashedNodeRef, SimpleStores},
     types::{
         self, HyperAST, IterableChildren, NodeStore, Typed, WithChildren, WithHashs, WithStats,
-    },
+    }, PrimInt,
 };
 use hyper_ast_cvs_git::{
     git::Repo, multi_preprocessed, preprocessed::child_at_path_tracked,
@@ -881,10 +881,10 @@ impl<IdN: Clone, Idx> position_accessors::RootedPosition<IdN> for TargetCodeElem
 impl<IdN, Idx: PrimInt> position_accessors::WithPath<IdN> for TargetCodeElement<IdN, Idx> {}
 
 impl<IdN, Idx: PrimInt> position_accessors::WithPreOrderOffsets for TargetCodeElement<IdN, Idx> {
-    type It<'a> = std::slice::Iter<'a, Idx> where Idx: 'a, Self: 'a;
+    type It<'a> = std::iter::Copied<std::slice::Iter<'a, Idx>> where Idx: 'a, Self: 'a;
 
     fn iter_offsets(&self) -> Self::It<'_> {
-        self.path.iter()
+        self.path.iter().copied()
     }
 }
 

--- a/client/src/track/compute.rs
+++ b/client/src/track/compute.rs
@@ -1,57 +1,158 @@
+use hyper_ast::position::position_accessors::{self, SolvedPosition};
+use hyper_ast_cvs_git::no_space::{NoSpaceMarker, NoSpaceWrapper};
 
-fn aux_aux(
+use crate::utils::LPO;
+
+use super::*;
+
+struct MappingTracker<R: ConfiguredRepoTrait> {
+    repo_handle: R,
+}
+
+impl<R: ConfiguredRepoTrait> MappingTracker<R> {
+    fn with_flags(self, flags: &Flags) -> Self {
+        self
+    }
+}
+
+struct MappingTracker2<'x, 'y, HAST, R: ConfiguredRepoTrait> {
+    repo_handle: &'x R,
+    stores: &'y HAST,
+    // no_spaces_path_to_target: Vec<HAST::Idx>,
+}
+
+impl<'x, 'store, HAST, R: ConfiguredRepoTrait> MappingTracker2<'x, 'store, HAST, R> {
+    fn new(&self, repo_handle: &'x R, stores: &'store HAST) -> Self {
+        Self {
+            repo_handle,
+            stores,
+        }
+    }
+    fn change_store(&self, repo_handle: &'x R, stores: &'store HAST) -> Self {
+        Self {
+            repo_handle,
+            stores,
+        }
+    }
+}
+
+struct MappingTracker3<'store, HAST> {
+    stores: &'store HAST,
+    // no_spaces_path_to_target: Vec<HAST::Idx>,
+}
+
+impl<'store, HAST> MappingTracker3<'store, HAST> {
+    fn new(stores: &'store HAST) -> Self {
+        Self { stores }
+    }
+    fn size(&self, other_tr: &HAST::IdN, current_tr: &HAST::IdN) -> usize
+    where
+        HAST: HyperAST<'store>,
+        HAST::T: types::WithStats,
+    {
+        let node_store = self.stores.node_store();
+        let src_size: usize = node_store.resolve(&other_tr).size();
+        let dst_size: usize = node_store.resolve(&current_tr).size();
+        src_size + dst_size
+    }
+}
+
+impl<'x, 'store, HAST, R: ConfiguredRepoTrait> MappingTracker2<'x, 'store, HAST, R> {
+    fn size_not_working(&self, other_tr: &HAST::IdN, current_tr: &HAST::IdN) -> usize
+    where
+        HAST: HyperAST<'store> + NoSpaceMarker,
+        HAST: no_space::AsNoSpace,
+        for<'s> HAST::T: types::WithSerialization,
+        HAST::R: HyperAST<'store, IdN = HAST::IdN>,
+        for<'s> <HAST::R as HyperAST<'store>>::T: types::WithStats,
+    {
+        let stores = self.stores.as_nospaces();
+        let node_store = stores.node_store();
+
+        let src_size: usize = node_store.resolve(&other_tr).size();
+        let dst_size: usize = node_store.resolve(&current_tr).size();
+        src_size + dst_size
+    }
+    fn compute_matches<P>(
+        &self,
+        current_tr: HAST::IdN,
+        target: &P,
+    ) -> (
+        LocalPieceOfCode<HAST::IdN, HAST::Idx>,
+        Vec<LocalPieceOfCode<HAST::IdN, HAST::Idx>>,
+    )
+    where
+        HAST: HyperAST<'store>,
+        HAST::T: types::WithSerialization,
+        for<'a> (&'store HAST, &'a P): Into<LocalPieceOfCode<HAST::IdN, HAST::Idx>>,
+    {
+        // let path_to_target = target.iter();
+
+        let c: LocalPieceOfCode<_, _> = Into::into((self.stores, target));
+
+        // let (pos, path_ids) = hyper_ast::position::compute_position_and_nodes(
+        //     current_tr,
+        //     &mut path_to_target.map(|x| *x),
+        //     self.stores,
+        // );
+        // dbg!();
+        // let range = pos.range();
+        // let c = LocalPieceOfCode::from_pos(&pos);
+        let matches = vec![c.clone()];
+        let src = c;
+        (src, matches)
+    }
+}
+
+pub(super) fn do_tracking<'store, 'p, P>(
     repo_handle: &impl ConfiguredRepoTrait,
-    src_tr: NodeIdentifier,
-    dst_tr: NodeIdentifier,
-    path_to_target: Vec<u16>,
-    no_spaces_path_to_target: Vec<u16>,
+    current_tr: NodeIdentifier,
+    other_tr: NodeIdentifier,
     flags: &Flags,
-    start: usize,
-    end: usize,
     partial_decomps: &PartialDecompCache,
     mappings_alone: &MappingAloneCache,
-    repositories: std::sync::RwLockReadGuard<multi_preprocessed::PreProcessedRepositories>,
-    dst_oid: hyper_ast_cvs_git::git::Oid,
-    target_node: NodeIdentifier,
-) -> MappingResult {
+    repositories: &'store multi_preprocessed::PreProcessedRepositories,
+    dst_oid: impl ToString,
+    no_spaces_path_to_target: Vec<super::Idx>,
+    target: &'p P,
+) -> MappingResult<NodeIdentifier, super::Idx>
+where
+    P: SolvedPosition<NodeIdentifier>
+        + position_accessors::WithPreOrderOffsets<Idx = super::Idx>
+        + position_accessors::OffsetPostionT<NodeIdentifier, IdO = usize>,
+    P::It<'p>: Clone,
+{
+    // let (target_node, target_range, path_to_target) = (
+    //     target.node(),
+    //     target.start()..target.end(),
+    //     target.iter_offsets(),
+    // );
     let with_spaces_stores = &repositories.processor.main_stores;
-    let stores = &no_space::as_nospaces(with_spaces_stores);
-    let node_store = &stores.node_store;
+    let tracker_nospace = MappingTracker3 {
+        stores: &hyper_ast_cvs_git::no_space::IntoNoSpaceGAT::as_nospaces(with_spaces_stores),
+    };
+    let postprocess_matching = |p: LocalPieceOfCode<super::IdN, super::Idx>| {
+        p.globalize(repo_handle.spec().clone(), dst_oid.to_string())
+    };
+
     // NOTE: persists mappings, could also easily persist diffs,
-    // but some compression on mappins could help
+    // but some compression on mappings could help
     // such as, not storing the decompression arenas
     // or encoding mappings more efficiently considering that most slices could simply by represented as ranges (ie. mapped identical subtrees)
+    // or only storing the mapping costly to compute
     // let mapper = lazy_mapping(repos, &mut state.mappings, src_tr, dst_tr);
 
-    dbg!(src_tr, dst_tr);
-    if src_tr == dst_tr {
-        let src_size = stores.node_store.resolve(src_tr).size();
-        let dst_size = stores.node_store.resolve(dst_tr).size();
-        let nodes = src_size + dst_size;
-        let (pos, path_ids) = compute_position_and_nodes(
-            dst_tr,
-            &mut path_to_target.iter().copied(),
-            with_spaces_stores,
-        );
-        dbg!();
-        let range = pos.range();
-        let matches = vec![PieceOfCode {
-            user: repo_handle.spec().user.clone(),
-            name: repo_handle.spec().name.clone(),
-            commit: dst_oid.to_string(),
-            file: pos.file().to_str().unwrap().to_string(),
-            start: range.start,
-            end: range.end,
-            path: path_to_target.iter().map(|x| *x as usize).collect(),
-            path_ids: path_ids.clone(),
-        }];
-        let src = LocalPieceOfCode {
-            file: pos.file().to_string_lossy().to_string(),
-            start,
-            end,
-            path: path_to_target.iter().map(|x| *x as usize).collect(),
-            path_ids,
+    // dbg!(src_tr, dst_tr);
+    if current_tr == other_tr {
+        let nodes = tracker_nospace.size(&current_tr, &other_tr);
+        let (src, matches) = {
+            let c = compute_local2(other_tr, target, with_spaces_stores);
+            let matches = vec![c.clone()];
+            let src = c;
+            (src, matches)
         };
+
+        let matches = matches.into_iter().map(postprocess_matching).collect();
         if flags.some() {
             return MappingResult::Skipped {
                 nodes,
@@ -62,417 +163,59 @@ fn aux_aux(
             return MappingResult::Direct { src, matches };
         }
     }
-    let pair = get_pair_simp(partial_decomps, stores, &src_tr, &dst_tr);
+    let stores = &no_space::as_nospaces(with_spaces_stores);
+    let node_store = &stores.node_store;
+    let mut pair = get_pair_simp(partial_decomps, stores, &current_tr, &other_tr);
 
     if flags.some() {
         dbg!();
-
-        let mapped = {
-            let mappings_cache = mappings_alone;
-            let hyperast = stores;
-            let src = &src_tr;
-            let dst = &dst_tr;
-            let (src_arena, dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
-            matching::top_down(hyperast, src_arena, dst_arena)
-        };
-        let (mapper_src_arena, mapper_dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
-        let mapper_mappings = &mapped;
-        let mut curr = mapper_src_arena.root();
-        let mut path = &no_spaces_path_to_target[..];
-        let flags: EnumSet<_> = flags.into();
-        loop {
-            dbg!(path);
-            let dsts = mapper_mappings.get_dsts(&curr);
-            let curr_flags = FlagsE::Upd | FlagsE::Child | FlagsE::SimChild; //  | FlagsE::ExactChild
-            let parent_flags = curr_flags | FlagsE::Parent | FlagsE::SimParent; //  | FlagsE::ExactParent
-            if dsts.is_empty() {
-                // continue through path_to_target
-                dbg!(curr);
-            } else if path.len() == 0 {
-                // need to check curr node flags
-                if flags.is_subset(curr_flags) {
-                    // only trigger on curr and children changed
-
-                    let src_size = stores.node_store.resolve(src_tr).size();
-                    let dst_size = stores.node_store.resolve(dst_tr).size();
-                    let nodes = src_size + dst_size;
-                    let nodes = 500_000;
-
-                    return MappingResult::Skipped {
-                        nodes,
-                        src: {
-                            let (pos, path_ids) = compute_position_and_nodes(
-                                src_tr,
-                                &mut path_to_target.iter().copied(),
-                                with_spaces_stores,
-                            );
-
-                            LocalPieceOfCode {
-                                file: pos.file().to_string_lossy().to_string(),
-                                start,
-                                end,
-                                path: path_to_target.iter().map(|x| *x as usize).collect(),
-                                path_ids,
-                            }
-                        },
-                        next: dsts
-                            .iter()
-                            .map(|x| {
-                                let path_dst = mapper_dst_arena.path(&mapper_dst_arena.root(), x);
-                                let (path_dst,) = path_with_spaces(
-                                    dst_tr,
-                                    &mut path_dst.iter().copied(),
-                                    &repositories.processor.main_stores,
-                                );
-                                let (pos, path_ids) = compute_position_and_nodes(
-                                    dst_tr,
-                                    &mut path_dst.iter().copied(),
-                                    with_spaces_stores,
-                                );
-                                let range = pos.range();
-                                PieceOfCode {
-                                    user: repo_handle.spec().user.clone(),
-                                    name: repo_handle.spec().name.clone(),
-                                    commit: dst_oid.to_string(),
-                                    file: pos.file().to_str().unwrap().to_string(),
-                                    start: range.start,
-                                    end: range.end,
-                                    path: path_dst.iter().map(|x| *x as usize).collect(),
-                                    path_ids,
-                                }
-                            })
-                            .collect(),
-                    };
-                }
-                // also the type of src and dsts
-                // also check it file path changed
-                // can we test if parent changed ? at least we can ckeck some attributes
-            } else if path.len() == 1 {
-                // need to check parent node flags
-                if flags.is_subset(parent_flags) {
-                    // only trigger on parent, curr and children changed
-                    let src_size = stores.node_store.resolve(src_tr).size();
-                    let dst_size = stores.node_store.resolve(dst_tr).size();
-                    let nodes = src_size + dst_size;
-                    let nodes = 500_000;
-                    return MappingResult::Skipped {
-                        nodes,
-                        src: {
-                            let (pos, path_ids) = compute_position_and_nodes(
-                                src_tr,
-                                &mut path_to_target.iter().copied(),
-                                with_spaces_stores,
-                            );
-
-                            LocalPieceOfCode {
-                                file: pos.file().to_string_lossy().to_string(),
-                                start,
-                                end,
-                                path: path_to_target.iter().map(|x| *x as usize).collect(),
-                                path_ids,
-                            }
-                        },
-                        next: dsts
-                            .iter()
-                            .map(|x| {
-                                let mut path_dst =
-                                    mapper_dst_arena.path(&mapper_dst_arena.root(), x);
-                                path_dst.extend(path); // WARN with similarity it might not be possible to simply concat path...
-                                let (path_dst,) = path_with_spaces(
-                                    dst_tr,
-                                    &mut path_dst.iter().copied(),
-                                    &repositories.processor.main_stores,
-                                );
-                                let (pos, path_ids) = compute_position_and_nodes(
-                                    dst_tr,
-                                    &mut path_dst.iter().copied(),
-                                    with_spaces_stores,
-                                );
-                                let range = pos.range();
-                                PieceOfCode {
-                                    user: repo_handle.spec().user.clone(),
-                                    name: repo_handle.spec().name.clone(),
-                                    commit: dst_oid.to_string(),
-                                    file: pos.file().to_str().unwrap().to_string(),
-                                    start: range.start,
-                                    end: range.end,
-                                    path: path_dst.iter().map(|x| *x as usize).collect(),
-                                    path_ids,
-                                }
-                            })
-                            .collect(),
-                    };
-                }
-                // also the type of src and dsts
-                // also check if file path changed
-                // can we test if parent changed ? at least we can ckeck some attributes
-            } else {
-                // need to check flags, the type of src and dsts
-                if flags.is_subset(parent_flags) {
-                    // only trigger on parent, curr and children changed
-                    let src_size = stores.node_store.resolve(src_tr).size();
-                    let dst_size = stores.node_store.resolve(dst_tr).size();
-                    let nodes = src_size + dst_size;
-                    let nodes = 500_000;
-                    return MappingResult::Skipped {
-                        nodes,
-                        src: {
-                            let (pos, path_ids) = compute_position_and_nodes(
-                                src_tr,
-                                &mut path_to_target.iter().copied(),
-                                with_spaces_stores,
-                            );
-
-                            LocalPieceOfCode {
-                                file: pos.file().to_string_lossy().to_string(),
-                                start,
-                                end,
-                                path: path_to_target.iter().map(|x| *x as usize).collect(),
-                                path_ids,
-                            }
-                        },
-                        next: dsts
-                            .iter()
-                            .map(|x| {
-                                let mut path_dst =
-                                    mapper_dst_arena.path(&mapper_dst_arena.root(), x);
-                                path_dst.extend(path); // WARN with similarity it might not be possible to simply concat path...
-                                let (path_dst,) = path_with_spaces(
-                                    dst_tr,
-                                    &mut path_dst.iter().copied(),
-                                    &repositories.processor.main_stores,
-                                );
-                                let (pos, path_ids) = compute_position_and_nodes(
-                                    dst_tr,
-                                    &mut path_dst.iter().copied(),
-                                    with_spaces_stores,
-                                );
-                                let range = pos.range();
-                                PieceOfCode {
-                                    user: repo_handle.spec().user.clone(),
-                                    name: repo_handle.spec().name.clone(),
-                                    commit: dst_oid.to_string(),
-                                    file: pos.file().to_str().unwrap().to_string(),
-                                    start: range.start,
-                                    end: range.end,
-                                    path: path_dst.iter().map(|x| *x as usize).collect(),
-                                    path_ids,
-                                }
-                            })
-                            .collect(),
-                    };
-                }
-                // also check if file path changed
-                // can we test if parent changed ? at least we can ckeck some attributes
-            }
-
-            let Some(i) = path.get(0) else {
-                break;
-            };
-            path = &path[1..];
-            let cs = mapper_src_arena.decompress_children(node_store, &curr);
-            if cs.is_empty() {
-                break;
-            }
-            curr = cs[*i as usize];
+        if let Some(value) = track_top_down(
+            current_tr,
+            other_tr,
+            &mut pair,
+            &no_spaces_path_to_target,
+            flags,
+            target,
+            with_spaces_stores,
+            stores,
+            postprocess_matching,
+        ) {
+            return value;
         }
     }
 
-    let mapped = {
-        let mappings_cache = mappings_alone;
-        use hyper_diff::matchers::mapping_store::MappingStore;
-        use hyper_diff::matchers::mapping_store::VecStore;
-        let hyperast = stores;
-        use hyper_diff::matchers::Mapping;
-
-        dbg!();
-        match mappings_cache.entry((src_tr, dst_tr)) {
-            dashmap::mapref::entry::Entry::Occupied(entry) => entry.into_ref().downgrade(),
-            dashmap::mapref::entry::Entry::Vacant(entry) => {
-                let mappings = VecStore::default();
-                let (src_arena, dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
-                dbg!(src_arena.len());
-                dbg!(dst_arena.len());
-                let src_size = stores.node_store.resolve(src_tr).size();
-                let dst_size = stores.node_store.resolve(dst_tr).size();
-                dbg!(src_size);
-                dbg!(dst_size);
-                let mut mapper = Mapper {
-                    hyperast,
-                    mapping: Mapping {
-                        src_arena,
-                        dst_arena,
-                        mappings,
-                    },
-                };
-                dbg!();
-                dbg!(mapper.mapping.src_arena.len());
-                dbg!(mapper.mapping.dst_arena.len());
-                mapper.mapping.mappings.topit(
-                    mapper.mapping.src_arena.len(),
-                    mapper.mapping.dst_arena.len(),
-                );
-                dbg!();
-
-                let vec_store = matching::full2(hyperast, mapper);
-
-                dbg!();
-                entry
-                    .insert((crate::MappingStage::Bottomup, vec_store))
-                    .downgrade()
-            }
-        }
-    };
+    let mapped =
+        compute_mappings_bottom_up(mappings_alone, stores, current_tr, other_tr, &mut pair);
     let (mapper_src_arena, mapper_dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
     let mapper_mappings = &mapped.1;
     let root = mapper_src_arena.root();
     let mapping_target =
         mapper_src_arena.child_decompressed(node_store, &root, &no_spaces_path_to_target);
 
-    let mut matches = vec![];
     if let Some(mapped) = mapper_mappings.get_dst(&mapping_target) {
-        let mapped = mapper_dst_arena.decompress_to(node_store, &mapped);
-        let path = mapper_dst_arena.path(&mapper_dst_arena.root(), &mapped);
-        let mut path_ids = vec![mapper_dst_arena.original(&mapped)];
-        mapper_dst_arena
-            .parents(mapped)
-            .map(|i| mapper_dst_arena.original(&i))
-            .collect_into(&mut path_ids);
-        path_ids.pop();
-        assert_eq!(path.len(), path_ids.len());
-        let (path,) = path_with_spaces(
-            dst_tr,
-            &mut path.iter().copied(),
-            &repositories.processor.main_stores,
-        );
-        let (pos, mapped_node) =
-            compute_position(dst_tr, &mut path.iter().copied(), with_spaces_stores);
-        dbg!(&pos);
-        dbg!(&mapped_node);
-        let mut flagged = false;
-        let mut triggered = false;
-        if flags.exact_child {
-            flagged = true;
-            dbg!();
-            triggered |= target_node != mapped_node;
-        }
-        if flags.child || flags.sim_child {
-            flagged = true;
-            dbg!();
-
-            let target_node = stores.node_store.resolve(target_node);
-            let mapped_node = stores.node_store.resolve(mapped_node);
-            if flags.sim_child {
-                triggered |= target_node.hash(&types::HashKind::structural())
-                    != mapped_node.hash(&types::HashKind::structural());
-            } else {
-                triggered |= target_node.hash(&types::HashKind::label())
-                    != mapped_node.hash(&types::HashKind::label());
-            }
-        }
-        if flags.upd {
-            flagged = true;
-            dbg!();
-            // TODO need role name
-            // let target_ident = child_by_type(stores, target_node, &Type::Identifier);
-            // let mapped_ident = child_by_type(stores, mapped_node, &Type::Identifier);
-            // if let (Some(target_ident), Some(mapped_ident)) = (target_ident, mapped_ident) {
-            //     let target_node = stores.node_store.resolve(target_ident.0);
-            //     let target_ident = target_node.try_get_label();
-            //     let mapped_node = stores.node_store.resolve(mapped_ident.0);
-            //     let mapped_ident = mapped_node.try_get_label();
-            //     triggered |= target_ident != mapped_ident;
-            // }
-        }
-        if flags.parent {
-            flagged = true;
-            dbg!();
-
-            let target_parent = mapper_src_arena.parent(&mapping_target);
-            let target_parent = target_parent.map(|x| mapper_src_arena.original(&x));
-            let mapped_parent = mapper_dst_arena.parent(&mapped);
-            let mapped_parent = mapped_parent.map(|x| mapper_dst_arena.original(&x));
-            triggered |= target_parent != mapped_parent;
-        }
-        // if flags.meth {
-        //     flagged = true;
-        //     dbg!();
-        // }
-        // if flags.typ {
-        //     flagged = true;
-        //     dbg!();
-        // }
-        // if flags.top {
-        //     flagged = true;
-        //     dbg!();
-        // }
-        // if flags.file {
-        //     flagged = true;
-        //     dbg!();
-        // }
-        // if flags.pack {
-        //     flagged = true;
-        //     dbg!();
-        // }
-        // TODO add flags for artefacts (tests, prod code, build, lang, misc)
-        // TODO add flags for similarity comps
-        let range = pos.range();
-        matches.push(PieceOfCode {
-            user: repo_handle.spec().user.clone(),
-            name: repo_handle.spec().name.clone(),
-            commit: dst_oid.to_string(),
-            file: pos.file().to_str().unwrap().to_string(),
-            start: range.start,
-            end: range.end,
-            path: path.iter().map(|x| *x as usize).collect(),
-            path_ids: path_ids.clone(),
-        });
-        if flagged && !triggered {
-            use hyper_ast::types::WithStats;
-            let src_size = stores.node_store.resolve(src_tr).size();
-            let dst_size = stores.node_store.resolve(dst_tr).size();
-            let nodes = src_size + dst_size;
-            return MappingResult::Skipped {
-                nodes,
-                src: {
-                    let (pos, path_ids) = compute_position_and_nodes(
-                        src_tr,
-                        &mut path_to_target.iter().copied(),
-                        with_spaces_stores,
-                    );
-
-                    LocalPieceOfCode {
-                        file: pos.file().to_string_lossy().to_string(),
-                        start,
-                        end,
-                        path: path_to_target.iter().map(|x| *x as usize).collect(),
-                        path_ids,
-                    }
-                },
-                next: matches,
-            };
-        }
-        let path = path_to_target.iter().map(|x| *x as usize).collect();
-        let (target_pos, target_path_ids) = compute_position_and_nodes(
-            src_tr,
-            &mut path_to_target.iter().copied(),
+        return track_with_mappings(
+            mapper_dst_arena,
+            mapped,
+            other_tr,
+            repositories,
             with_spaces_stores,
+            flags,
+            stores,
+            mapper_src_arena,
+            mapping_target,
+            current_tr,
+            target,
+            postprocess_matching,
         );
-        return MappingResult::Direct {
-            src: LocalPieceOfCode {
-                file: target_pos.file().to_string_lossy().to_string(),
-                start,
-                end,
-                path,
-                path_ids: target_path_ids,
-            },
-            matches,
-        };
     }
 
     for parent_target in mapper_src_arena.parents(mapping_target) {
         if let Some(mapped_parent) = mapper_mappings.get_dst(&parent_target) {
             let mapped_parent = mapper_dst_arena.decompress_to(node_store, &mapped_parent);
+            assert_eq!(
+                other_tr,
+                mapper_dst_arena.original(&mapper_dst_arena.root())
+            );
             let path = mapper_dst_arena.path(&mapper_dst_arena.root(), &mapped_parent);
             let mut path_ids = vec![mapper_dst_arena.original(&mapped_parent)];
             mapper_dst_arena
@@ -482,789 +225,499 @@ fn aux_aux(
             path_ids.pop();
             assert_eq!(path.len(), path_ids.len());
             let (path,) = path_with_spaces(
-                dst_tr,
+                other_tr,
                 &mut path.iter().copied(),
                 &repositories.processor.main_stores,
             );
             let (pos, mapped_node) =
-                compute_position(dst_tr, &mut path.iter().copied(), with_spaces_stores);
-            dbg!(&pos);
+                compute_position(other_tr, &mut path.iter().copied(), with_spaces_stores);
             dbg!(&mapped_node);
-            let range = pos.range();
-            let fallback = PieceOfCode {
-                user: repo_handle.spec().user.clone(),
-                name: repo_handle.spec().name.clone(),
-                commit: dst_oid.to_string(),
-                file: pos.file().to_str().unwrap().to_string(),
-                start: range.start,
-                end: range.end,
-                path: path.iter().map(|x| *x as usize).collect(),
-                path_ids: path_ids.clone(),
-            };
+            assert_eq!(&mapped_node, path_ids.last().unwrap());
+            let fallback = LocalPieceOfCode::from_file_and_range(
+                pos.file(),
+                target.start()..target.end(),
+                path,
+                path_ids,
+            )
+            .globalize(repo_handle.spec().clone(), dst_oid.to_string());
 
             let src = {
-                let path = path_to_target.iter().map(|x| *x as usize).collect();
+                let path = target.iter_offsets().copied().collect();
                 let (target_pos, target_path_ids) = compute_position_and_nodes(
-                    src_tr,
-                    &mut path_to_target.iter().copied(),
+                    current_tr,
+                    &mut target.iter_offsets().copied(),
                     with_spaces_stores,
                 );
-                LocalPieceOfCode {
-                    file: target_pos.file().to_string_lossy().to_string(),
-                    start,
-                    end,
+                LocalPieceOfCode::from_file_and_range(
+                    target_pos.file(),
+                    target.start()..target.end(),
                     path,
-                    path_ids: target_path_ids,
-                }
+                    target_path_ids,
+                )
             };
             return MappingResult::Missing { src, fallback };
         };
     }
-    let path = path_to_target.iter().map(|x| *x as usize).collect();
-    let (target_pos, target_path_ids) = compute_position_and_nodes(
-        src_tr,
-        &mut path_to_target.iter().copied(),
-        with_spaces_stores,
+    // lets try
+    unreachable!()
+    // let path = path_to_target.clone();
+    // let (target_pos, target_path_ids) = compute_position_and_nodes(
+    //     other_tr,
+    //     &mut path_to_target.iter().copied(),
+    //     with_spaces_stores,
+    // );
+    // // TODO what should be done if there is no match ?
+    // MappingResult::Direct {
+    //     src: LocalPieceOfCode::from_file_and_range(
+    //         target_pos.file(),
+    //         target_range,
+    //         path,
+    //         target_path_ids,
+    //     ),
+    //     matches: vec![],
+    // }
+}
+
+type IdD = u32;
+
+fn track_with_mappings<'store, C, P>(
+    mapper_dst_arena: &mut hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
+        NoSpaceWrapper<'store, super::IdN>,
+        IdD,
+    >,
+    mapped: IdD,
+    other_tr: super::IdN,
+    repositories: &multi_preprocessed::PreProcessedRepositories,
+    with_spaces_stores: &SimpleStores<TStore>,
+    flags: &Flags,
+    stores: &'store types::SimpleHyperAST<
+        NoSpaceWrapper<'store, NodeIdentifier>,
+        &TStore,
+        no_space::NoSpaceNodeStoreWrapper<'store>,
+        &hyper_ast::store::labels::LabelStore,
+    >,
+    mapper_src_arena: &mut hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
+        NoSpaceWrapper<'store, super::IdN>,
+        IdD,
+    >,
+    mapping_target: IdD,
+    current_tr: super::IdN,
+    target: &P,
+    postprocess_matching: impl Fn(LocalPieceOfCode<super::IdN, super::Idx>) -> C,
+) -> MappingResult<super::IdN, super::Idx, C>
+where
+    P: SolvedPosition<NodeIdentifier>
+        + position_accessors::WithPreOrderOffsets<Idx = super::Idx>
+        + position_accessors::OffsetPostionT<NodeIdentifier, IdO = usize>,
+{
+    let mut matches = vec![];
+    let node_store = &stores.node_store;
+    let mapped = mapper_dst_arena.decompress_to(node_store, &mapped);
+    assert_eq!(
+        other_tr,
+        mapper_dst_arena.original(&mapper_dst_arena.root())
     );
-    // TODO what should be done if there is no match ?
-    MappingResult::Direct {
-        src: LocalPieceOfCode {
-            file: target_pos.file().to_string_lossy().to_string(),
-            start,
-            end,
-            path,
-            path_ids: target_path_ids,
-        },
-        matches,
-    }
-}
-
-// fn diff<'a>(
-//     repositories: &'a multi_preprocessed::PreProcessedRepositories,
-//     mappings: &'a mut crate::MappingCache,
-//     src_tr: NodeIdentifier,
-//     dst_tr: NodeIdentifier,
-// ) -> &'a hyper_diff::matchers::Mapping<
-//     hyper_diff::decompressed_tree_store::CompletePostOrder<
-//         hyper_ast::store::nodes::legion::HashedNodeRef<'a>,
-//         u32,
-//     >,
-//     hyper_diff::decompressed_tree_store::CompletePostOrder<
-//         hyper_ast::store::nodes::legion::HashedNodeRef<'a>,
-//         u32,
-//     >,
-//     hyper_diff::matchers::mapping_store::VecStore<u32>,
-// > {
-//     use hyper_diff::decompressed_tree_store::CompletePostOrder;
-//     let mapped = mappings.entry((src_tr, dst_tr)).or_insert_with(|| {
-//         hyper_diff::algorithms::gumtree_lazy::diff(
-//             &repositories.processor.main_stores,
-//             &src_tr,
-//             &dst_tr,
-//         )
-//         .mapper
-//         .persist()
-//     });
-//     unsafe { Mapper::<_,CompletePostOrder<_,_>,CompletePostOrder<_,_>,_>::unpersist(&repositories.processor.main_stores, &*mapped) }
-// }
-
-// WARN lazy subtrees are not complete
-fn lazy_mapping<'a>(
-    repositories: &'a multi_preprocessed::PreProcessedRepositories,
-    mappings: &'a crate::MappingCache,
-    src_tr: NodeIdentifier,
-    dst_tr: NodeIdentifier,
-) -> dashmap::mapref::one::RefMut<
-    'a,
-    (NodeIdentifier, NodeIdentifier),
-    hyper_diff::matchers::Mapping<
-        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
-            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
-            u32,
-        >,
-        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
-            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
-            u32,
-        >,
-        hyper_diff::matchers::mapping_store::VecStore<u32>,
-    >,
-> {
-    use hyper_ast::types::HyperAST;
-    use hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder;
-    use hyper_diff::matchers::heuristic::gt::{
-        lazy2_greedy_bottom_up_matcher::GreedyBottomUpMatcher,
-        lazy2_greedy_subtree_matcher::LazyGreedySubtreeMatcher,
+    let path = mapper_dst_arena.path(&mapper_dst_arena.root(), &mapped);
+    let path_ids = {
+        let mut path_ids = vec![mapper_dst_arena.original(&mapped)];
+        mapper_dst_arena
+            .parents(mapped)
+            .map(|i| mapper_dst_arena.original(&i))
+            .collect_into(&mut path_ids);
+        path_ids.pop();
+        path_ids
     };
-    use hyper_diff::matchers::mapping_store::DefaultMultiMappingStore;
-    use hyper_diff::matchers::mapping_store::MappingStore;
-    use hyper_diff::matchers::mapping_store::VecStore;
-    let mapped = mappings.entry((src_tr, dst_tr)).or_insert_with(|| {
-        let hyperast = &repositories.processor.main_stores;
-        let src = &src_tr;
-        let dst = &dst_tr;
-        let now = Instant::now();
-        let mapper: Mapper<_, LazyPostOrder<_, u32>, LazyPostOrder<_, u32>, VecStore<_>> =
-            hyperast.decompress_pair(src, dst).into();
-        let subtree_prepare_t = now.elapsed().as_secs_f64();
-        let now = Instant::now();
-        let mapper =
-            LazyGreedySubtreeMatcher::<_, _, _, _>::match_it::<DefaultMultiMappingStore<_>>(mapper);
-        let subtree_matcher_t = now.elapsed().as_secs_f64();
-        let subtree_mappings_s = mapper.mappings().len();
-        dbg!(&subtree_matcher_t, &subtree_mappings_s);
-        let bottomup_prepare_t = 0.;
-        let now = Instant::now();
-        let mapper = GreedyBottomUpMatcher::<_, _, _, _, VecStore<_>>::match_it(mapper);
-        dbg!(&now.elapsed().as_secs_f64());
-        let bottomup_matcher_t = now.elapsed().as_secs_f64();
-        let bottomup_mappings_s = mapper.mappings().len();
-        dbg!(&bottomup_matcher_t, &bottomup_mappings_s);
-        // let now = Instant::now();
-
-        // NOTE could also have completed trees
-        // let node_store = hyperast.node_store();
-        // let mapper = mapper.map(
-        //     |src_arena| CompletePostOrder::from(src_arena.complete(node_store)),
-        //     |dst_arena| {
-        //         let complete = CompletePostOrder::from(dst_arena.complete(node_store));
-        //         SimpleBfsMapper::from(node_store, complete)
-        //     },
-        // );
-
-        // NOTE we do not use edit scripts here
-        // let prepare_gen_t = now.elapsed().as_secs_f64();
-        // let now = Instant::now();
-        // let actions = ScriptGenerator::compute_actions(mapper.hyperast, &mapper.mapping).ok();
-        // let gen_t = now.elapsed().as_secs_f64();
-        // dbg!(gen_t);
-        // let mapper = mapper.map(|x| x, |dst_arena| dst_arena.back);
-        Mapper::<_, LazyPostOrder<_, _>, LazyPostOrder<_, _>, _>::persist(mapper)
-    });
-    pub unsafe fn unpersist<'a>(
-        _hyperast: &'a SimpleStores<TStore>,
-        p: dashmap::mapref::one::RefMut<
-            'a,
-            (NodeIdentifier, NodeIdentifier),
-            hyper_diff::matchers::Mapping<
-                LazyPostOrder<
-                    hyper_diff::decompressed_tree_store::PersistedNode<NodeIdentifier>,
-                    u32,
-                >,
-                LazyPostOrder<
-                    hyper_diff::decompressed_tree_store::PersistedNode<NodeIdentifier>,
-                    u32,
-                >,
-                VecStore<u32>,
-            >,
-        >,
-    ) -> dashmap::mapref::one::RefMut<
-        'a,
-        (NodeIdentifier, NodeIdentifier),
-        hyper_diff::matchers::Mapping<
-            LazyPostOrder<HashedNodeRef<'a, NodeIdentifier>, u32>,
-            LazyPostOrder<HashedNodeRef<'a, NodeIdentifier>, u32>,
-            VecStore<u32>,
-        >,
-    > {
-        unsafe { std::mem::transmute(p) }
+    assert_eq!(path.len(), path_ids.len());
+    let (path,) = path_with_spaces(
+        other_tr,
+        &mut path.iter().copied(),
+        &repositories.processor.main_stores,
+    );
+    let (pos, mapped_node) =
+        compute_position(other_tr, &mut path.iter().copied(), with_spaces_stores);
+    dbg!(&pos);
+    dbg!(&mapped_node);
+    let mut flagged = false;
+    let mut triggered = false;
+    if flags.exact_child {
+        flagged = true;
+        dbg!();
+        triggered |= target.node() != mapped_node;
     }
-    unsafe { unpersist(&repositories.processor.main_stores, mapped) }
-}
+    if flags.child || flags.sim_child {
+        flagged = true;
+        dbg!();
 
-struct RRR<'a>(
-    dashmap::mapref::one::Ref<
-        'a,
-        (NodeIdentifier, NodeIdentifier),
-        (
-            crate::MappingStage,
-            hyper_diff::matchers::mapping_store::VecStore<u32>,
-        ),
-    >,
-);
-
-mod my_dash {
-    use std::{
-        cell::UnsafeCell,
-        collections::hash_map::RandomState,
-        fmt::Debug,
-        hash::{BuildHasher, Hash},
-    };
-
-    use dashmap::{DashMap, RwLockWriteGuard, SharedValue};
-    use hashbrown::HashMap;
-
-    // pub fn entries<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone>(
-    //     map: DashMap<K, V, S>,
-    //     key1: K,
-    //     key2: K,
-    // ) -> Entry<'a, K, V, S> {
-    //     let hash = map.hash_usize(&key1);
-
-    //     let idx = map.determine_shard(hash);
-
-    //     let shard: RwLockWriteGuard<HashMap<K, SharedValue<V>, S>> = unsafe {
-    //         debug_assert!(idx < map.shards().len());
-
-    //         map.shards().get_unchecked(idx).write()
-    //     };
-
-    //     #[repr(transparent)]
-    //     struct MySharedValue<T> {
-    //         value: UnsafeCell<T>,
-    //     }
-
-    //     impl<T> MySharedValue<T> {
-    //         /// Get a mutable raw pointer to the underlying value
-    //         fn as_ptr(&self) -> *mut T {
-    //             self.value.get()
-    //         }
-    //     }
-    //     // SAFETY: Sharded and UnsafeCell are transparent wrappers of V
-    //     let shard: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard) };
-    //     if let Some((kptr, vptr)) = shard.get_key_value(&key1) {
-    //         unsafe {
-    //             let kptr: *const K = kptr;
-    //             // SAFETY: same memory layout because transparent and same fields
-    //             let vptr: &MySharedValue<V> = std::mem::transmute(&vptr);
-    //             let vptr: *mut V = vptr.as_ptr();
-    //             Entry::Occupied(OccupiedEntry::new(shard, key1, (kptr, vptr)))
-    //         }
-    //     } else {
-    //         unsafe {
-    //             // SAFETY: same memory layout because transparent and same fields
-    //             let shard: RwLockWriteGuard<HashMap<K, V, S>> = std::mem::transmute(shard);
-    //             Entry::Vacant(VacantEntry::new(shard, key1))
-    //         }
-    //     }
-    pub fn entries<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone>(
-        map: &'a DashMap<K, V, S>,
-        key1: K,
-        key2: K,
-    ) -> Entry<'a, K, V, S> {
-        assert!(key1 != key2, "keys should be different");
-        let hash1 = map.hash_usize(&key1);
-        let idx1 = map.determine_shard(hash1);
-        let hash2 = map.hash_usize(&key2);
-        let idx2 = map.determine_shard(hash2);
-
-        if idx1 == idx2 {
-            let shard = unsafe {
-                debug_assert!(idx1 < map.shards().len());
-                debug_assert!(idx2 < map.shards().len());
-                map.shards().get_unchecked(idx1).write()
-            };
-            // SAFETY: Sharded and UnsafeCell are transparent wrappers of V
-            let shard: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard) };
-            let elem1 = shard
-                .get_key_value(&key1)
-                .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
-            let elem2 = shard
-                .get_key_value(&key2)
-                .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
-            Entry {
-                shard1: shard,
-                shard2: None,
-                key1,
-                key2,
-                elem1,
-                elem2,
-            }
+        let target_node = stores.node_store.resolve(target.node());
+        let mapped_node = stores.node_store.resolve(mapped_node);
+        if flags.sim_child {
+            triggered |= target_node.hash(&types::HashKind::structural())
+                != mapped_node.hash(&types::HashKind::structural());
         } else {
-            let (shard1, shard2) = unsafe {
-                debug_assert!(idx1 < map.shards().len());
-                debug_assert!(idx2 < map.shards().len());
-                (
-                    map.shards().get_unchecked(idx1).write(),
-                    map.shards().get_unchecked(idx2).write(),
+            triggered |= target_node.hash(&types::HashKind::label())
+                != mapped_node.hash(&types::HashKind::label());
+        }
+    }
+    if flags.upd {
+        flagged = true;
+        dbg!();
+        // TODO need role name
+        // let target_ident = child_by_type(stores, target_node, &Type::Identifier);
+        // let mapped_ident = child_by_type(stores, mapped_node, &Type::Identifier);
+        // if let (Some(target_ident), Some(mapped_ident)) = (target_ident, mapped_ident) {
+        //     let target_node = stores.node_store.resolve(target_ident.0);
+        //     let target_ident = target_node.try_get_label();
+        //     let mapped_node = stores.node_store.resolve(mapped_ident.0);
+        //     let mapped_ident = mapped_node.try_get_label();
+        //     triggered |= target_ident != mapped_ident;
+        // }
+    }
+    if flags.parent {
+        flagged = true;
+        dbg!();
+
+        let target_parent = mapper_src_arena.parent(&mapping_target);
+        let target_parent = target_parent.map(|x| mapper_src_arena.original(&x));
+        let mapped_parent = mapper_dst_arena.parent(&mapped);
+        let mapped_parent = mapped_parent.map(|x| mapper_dst_arena.original(&x));
+        triggered |= target_parent != mapped_parent;
+    }
+    // if flags.meth {
+    //     flagged = true;
+    //     dbg!();
+    // }
+    // if flags.typ {
+    //     flagged = true;
+    //     dbg!();
+    // }
+    // if flags.top {
+    //     flagged = true;
+    //     dbg!();
+    // }
+    // if flags.file {
+    //     flagged = true;
+    //     dbg!();
+    // }
+    // if flags.pack {
+    //     flagged = true;
+    //     dbg!();
+    // }
+    // TODO add flags for artefacts (tests, prod code, build, lang, misc)
+    // TODO add flags for similarity comps
+    matches.push(postprocess_matching(LocalPieceOfCode::from_position(
+        &pos,
+        path.clone(),
+        path_ids.clone(),
+    )));
+    if flagged && !triggered {
+        let src_size = stores.node_store.resolve(current_tr).size();
+        let dst_size = stores.node_store.resolve(other_tr).size();
+        let nodes = src_size + dst_size;
+        MappingResult::Skipped {
+            nodes,
+            src: {
+                let (pos, path_ids) = compute_position_and_nodes(
+                    current_tr,
+                    &mut target.iter_offsets().copied(),
+                    with_spaces_stores,
+                );
+
+                LocalPieceOfCode::from_file_and_range(
+                    pos.file(),
+                    target.start()..target.end(),
+                    target.iter_offsets().copied().collect(),
+                    path_ids,
                 )
-            };
-            let shard1: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard1) };
-            let shard2: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard2) };
-            let elem1 = shard1
-                .get_key_value(&key1)
-                .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
-            let elem2 = shard2
-                .get_key_value(&key2)
-                .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
-            Entry {
-                shard1: shard1,
-                shard2: Some(shard2),
-                key1,
-                key2,
-                elem1,
-                elem2,
-            }
+            },
+            next: matches,
         }
-    }
-
-    unsafe fn as_ptr<'a, K: 'a + Eq + Hash, V: 'a>(kptr1: &K, vptr1: &V) -> (*const K, *mut V) {
-        let kptr1: *const K = kptr1;
-        // SAFETY: same memory layout because transparent and same fields
-        let vptr1: &MySharedValue<V> = std::mem::transmute(&vptr1);
-        let vptr1: *mut V = vptr1.as_ptr();
-        (kptr1, vptr1)
-    }
-
-    pub(super) unsafe fn shard_as_ptr<'a, V: 'a>(vptr1: &SharedValue<V>) -> *mut V {
-        // SAFETY: same memory layout because transparent and same fields
-        let vptr1: &MySharedValue<V> = std::mem::transmute(&vptr1);
-        let vptr1: *mut V = vptr1.as_ptr();
-        vptr1
-    }
-
-    pub(super) unsafe fn shard_as_ptr2<'a, V: 'a>(vptr1: &V) -> *mut V {
-        // SAFETY: same memory layout because transparent and same fields
-        let vptr1: &MySharedValue<V> = std::mem::transmute(&vptr1);
-        let vptr1: *mut V = vptr1.as_ptr();
-        vptr1
-    }
-
-    #[repr(transparent)]
-    struct MySharedValue<T> {
-        value: UnsafeCell<T>,
-    }
-
-    impl<T> MySharedValue<T> {
-        /// Get a mutable raw pointer to the underlying value
-        fn as_ptr(&self) -> *mut T {
-            self.value.get()
-        }
-    }
-    pub struct Entry<'a, K, V, S = RandomState> {
-        shard1: RwLockWriteGuard<'a, HashMap<K, V, S>>,
-        shard2: Option<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
-        elem1: Option<(*const K, *mut V)>,
-        elem2: Option<(*const K, *mut V)>,
-        key1: K,
-        key2: K,
-    }
-    unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Send for Entry<'a, K, V, S> {}
-    unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Sync for Entry<'a, K, V, S> {}
-
-    impl<'a, K: Clone + Eq + Hash + Debug, V: Debug, S: BuildHasher> Entry<'a, K, V, S> {
-        pub fn or_insert_with(
-            self,
-            value: impl FnOnce((Option<()>, Option<()>)) -> (Option<V>, Option<V>),
-        ) -> RefMut<'a, K, V, S> {
-            match self {
-                Entry {
-                    shard1,
-                    shard2,
-                    elem1: Some((k1, v1)),
-                    elem2: Some((k2, v2)),
-                    ..
-                } => {
-                    dbg!(v1);
-                    dbg!(v2);
-                    RefMut {
-                        guard1: shard1,
-                        guard2: shard2,
-                        k1,
-                        k2,
-                        v1,
-                        v2,
-                    }
-                }
-                Entry {
-                    mut shard1,
-                    shard2: None,
-                    elem1,
-                    elem2,
-                    key1,
-                    key2,
-                } => {
-                    let (r1, r2) = value((elem1.as_ref().map(|_| ()), elem2.as_ref().map(|_| ())));
-                    let k1 = key1.clone();
-                    let k2 = key2.clone();
-                    if elem1.is_none() {
-                        let value = r1.expect("some value");
-                        let key = key1;
-                        let shard = &mut shard1;
-                        insert2_p1(key, shard, value)
-                    }
-                    if elem2.is_none() {
-                        let value = r2.expect("some value");
-                        let key = key2;
-                        let shard = &mut shard1;
-                        insert2_p1(key, shard, value)
-                    }
-                    let (k1, v1) = elem1.unwrap_or_else(|| {
-                        let shard = &mut shard1;
-                        insert2_p2(&k1, shard)
-                    });
-                    let (k2, v2) = elem2.unwrap_or_else(|| {
-                        let shard = &mut shard1;
-                        insert2_p2(&k2, shard)
-                    });
-                    dbg!(v1);
-                    dbg!(v2);
-                    RefMut {
-                        guard1: shard1,
-                        guard2: None,
-                        k1,
-                        k2,
-                        v1,
-                        v2,
-                    }
-                }
-                Entry {
-                    mut shard1,
-                    shard2: Some(mut shard2),
-                    elem1,
-                    elem2,
-                    key1,
-                    key2,
-                } => {
-                    let (r1, r2) = value((elem1.as_ref().map(|_| ()), elem2.as_ref().map(|_| ())));
-                    // let (k1, v1) = elem1.unwrap_or_else(|| {
-                    //     let value = r1.expect("some value");
-                    //     let key = key1;
-                    //     let shard = &mut shard1;
-                    //     println!("{:p}", shard);
-                    //     println!("{:p}", &key);
-                    //     println!("{}", shard.hasher().hash_one(&key));
-                    //     insert2(key, shard, value)
-                    // });
-                    // let (k2, v2) = elem2.unwrap_or_else(|| {
-                    //     let value = r2.expect("some value");
-                    //     let key = key2;
-                    //     let shard = &mut shard2;
-                    //     insert2(key, shard, value)
-                    // });
-                    let k1 = key1.clone();
-                    let k2 = key2.clone();
-                    dbg!(&k1);
-                    dbg!(&k2);
-                    println!("{:p}", &k1);
-                    println!("{:p}", &k2);
-                    println!("{:p}", &r1);
-                    println!("{:p}", &r2);
-                    if elem1.is_none() {
-                        let value = r1.expect("some value");
-                        dbg!(&value);
-                        println!("{:p}", &value);
-                        let key = key1;
-                        let shard = &mut shard1;
-                        insert2_p1_shard(key, shard, value)
-                    }
-                    if elem2.is_none() {
-                        let value = r2.expect("some value");
-                        dbg!(&value);
-                        println!("{:p}", &value);
-                        let key = key2;
-                        let shard = &mut shard2;
-                        insert2_p1(key, shard, value)
-                    }
-                    let (k1, v1) = elem1.unwrap_or_else(|| {
-                        let shard = &mut shard1;
-                        dbg!(shard.hasher().hash_one(&k1));
-                        let shard: &mut RwLockWriteGuard<HashMap<K, SharedValue<V>>> =
-                            unsafe { std::mem::transmute(shard) };
-                        insert2_p2_shard(&k1, shard)
-                    });
-                    let (k2, v2) = elem2.unwrap_or_else(|| {
-                        let shard = &mut shard2;
-                        insert2_p2(&k2, shard)
-                    });
-                    println!("{:p}", &shard1);
-                    dbg!(shard1.len());
-                    println!("{:p}", &shard2);
-                    dbg!(shard2.len());
-                    dbg!(v1);
-                    dbg!(v2);
-                    RefMut {
-                        guard1: shard1,
-                        guard2: Some(shard2),
-                        k1,
-                        k2,
-                        v1,
-                        v2,
-                    }
-                }
-            }
-        }
-    }
-
-    fn insert2<'a, K: Eq + Hash, V, S: BuildHasher>(
-        key: K,
-        shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
-        value: V,
-    ) -> (*const K, *mut V) {
-        let c = unsafe { std::ptr::read(&key) };
-        shard.insert(key, value);
-        // let shard: &mut RwLockWriteGuard<HashMap<K, SharedValue<V>>> =
-        //     unsafe { std::mem::transmute(shard) };
-        {
-            // let shard: &'a mut RwLockWriteGuard<'a, HashMap<K, SharedValue<V>>> = shard;
-            unsafe {
-                use std::mem;
-                dbg!();
-                let (k, v) = shard.get_key_value(&c).unwrap();
-                dbg!();
-                let k = change_lifetime_const(k);
-                dbg!();
-                let v = &mut *shard_as_ptr2(v);
-                dbg!();
-                mem::forget(c);
-                dbg!();
-                (k, v)
-            }
-        }
-    }
-
-    fn insert2_p1<'a, K: Eq + Hash, V, S: BuildHasher>(
-        key: K,
-        shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
-        value: V,
-    ) {
-        println!("{:p}", &key);
-        println!("{}", shard.hasher().hash_one(&key));
-        println!("{:p}", &value);
-        shard.insert(key, value);
-    }
-
-    fn insert2_p1_shard<'a, K: Eq + Hash, V, S: BuildHasher>(
-        key: K,
-        shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
-        value: V,
-    ) {
-        println!("{:p}", &key);
-        println!("{}", shard.hasher().hash_one(&key));
-        println!("{:p}", &value);
-        // let shard: &mut RwLockWriteGuard<HashMap<K, SharedValue<V>>> =
-        //             unsafe { std::mem::transmute(shard) };
-        // let value: SharedValue<V> = SharedValue::new(value);
-        println!("{:p}", &key);
-        println!("{}", shard.hasher().hash_one(&key));
-        println!("{:p}", &value);
-        // todo!()
-        shard.insert(key, value);
-    }
-
-    fn insert2_p2<'a, K: Eq + Hash, V, S: BuildHasher>(
-        key: &K,
-        shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
-    ) -> (*const K, *mut V) {
-        unsafe {
-            use std::mem;
-            dbg!();
-            println!("{:p}", &key);
-            println!("{}", shard.hasher().hash_one(&key));
-            let (k, v) = shard.get_key_value(key).unwrap();
-            dbg!();
-            let k = change_lifetime_const(k);
-            dbg!();
-            let v = &mut *shard_as_ptr2(v);
-            dbg!();
-            (k, v)
-        }
-    }
-
-    fn insert2_p2_shard<'a, K: Eq + Hash, V, S: BuildHasher>(
-        key: &K,
-        shard: &mut RwLockWriteGuard<'a, HashMap<K, SharedValue<V>, S>>,
-    ) -> (*const K, *mut V) {
-        unsafe {
-            dbg!();
-            println!("{:p}", &key);
-            println!("{}", shard.hasher().hash_one(&key));
-            todo!();
-
-            let (k, v) = shard.get_key_value(key).unwrap();
-            dbg!();
-            let k = change_lifetime_const(k);
-            dbg!();
-            let v = &mut *shard_as_ptr(v);
-            dbg!();
-            (k, v)
-        }
-    }
-
-    fn insert<'a, K: Eq + Hash, V>(
-        key: K,
-        shard: &'a mut RwLockWriteGuard<'a, HashMap<K, SharedValue<V>>>,
-        value: SharedValue<V>,
-    ) -> (*const K, *mut V) {
-        unsafe {
-            use std::mem;
-            use std::ptr;
-            let c: K = ptr::read(&key);
-            dbg!();
-            println!("{:p}", &key);
-            println!("{}", shard.hasher().hash_one(&key));
-            println!("{:p}", &value);
-            {
-                // let shard: &mut RwLockWriteGuard<HashMap<K, V>> =
-                //     unsafe { std::mem::transmute(shard) };
-                // let value: V =
-                //     unsafe { std::mem::transmute(value) };
-                shard.insert(key, value);
-            }
-            dbg!();
-            let (k, v) = shard.get_key_value(&c).unwrap();
-            dbg!();
-            let k = change_lifetime_const(k);
-            dbg!();
-            let v = &mut *shard_as_ptr(v);
-            dbg!();
-            mem::forget(c);
-            dbg!();
-            (k, v)
-        }
-    }
-
-    /// # Safety
-    ///
-    /// Requires that you ensure the reference does not become invalid.
-    /// The object has to outlive the reference.
-    unsafe fn change_lifetime_const<'a, 'b, T>(x: &'a T) -> &'b T {
-        &*(x as *const T)
-    }
-
-    pub struct RefMut<'a, K, V, S = RandomState> {
-        guard1: RwLockWriteGuard<'a, HashMap<K, V, S>>,
-        guard2: Option<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
-        k1: *const K,
-        k2: *const K,
-        v1: *mut V,
-        v2: *mut V,
-    }
-
-    unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Send for RefMut<'a, K, V, S> {}
-    unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Sync for RefMut<'a, K, V, S> {}
-
-    impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMut<'a, K, V, S> {
-        pub fn value_mut(&mut self) -> (&mut V, &mut V) {
-            unsafe { (&mut *self.v1, &mut *self.v2) }
+    } else {
+        let path = target.iter_offsets().copied().collect();
+        let (target_pos, target_path_ids) = compute_position_and_nodes(
+            current_tr,
+            &mut target.iter_offsets().copied(),
+            with_spaces_stores,
+        );
+        MappingResult::Direct {
+            src: LocalPieceOfCode::from_file_and_range(
+                target_pos.file(),
+                target.start()..target.end(),
+                path,
+                target_path_ids,
+            ),
+            matches,
         }
     }
 }
 
-// WARN lazy subtrees are not complete
-fn lazy_subtree_mapping<'a, 'b>(
-    repositories: &'a multi_preprocessed::PreProcessedRepositories,
-    partial_comp_cache: &'a crate::PartialDecompCache,
-    src_tr: NodeIdentifier,
-    dst_tr: NodeIdentifier,
-) -> hyper_diff::matchers::Mapping<
-    dashmap::mapref::one::RefMut<
-        'a,
-        NodeIdentifier,
-        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
-            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
-            u32,
-        >,
+fn compute_mappings_bottom_up<'store, 'a, S>(
+    mappings_alone: &'a dashmap::DashMap<
+        (super::IdN, super::IdN),
+        (crate::MappingStage, mapping_store::VecStore<IdD>),
+        S,
     >,
-    dashmap::mapref::one::RefMut<
-        'a,
-        NodeIdentifier,
-        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
-            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
-            u32,
-        >,
+    stores: &'store types::SimpleHyperAST<
+        NoSpaceWrapper<'store, NodeIdentifier>,
+        &TStore,
+        no_space::NoSpaceNodeStoreWrapper<'store>,
+        &hyper_ast::store::labels::LabelStore,
     >,
-    mapping_store::MultiVecStore<u32>,
-> {
-    use hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder;
-    use hyper_diff::matchers::heuristic::gt::lazy2_greedy_subtree_matcher::LazyGreedySubtreeMatcher;
-    use hyper_diff::matchers::mapping_store::DefaultMultiMappingStore;
+    other_tr: super::IdN,
+    current_tr: super::IdN,
+    pair: &mut (
+        &mut LPO<NoSpaceWrapper<'store, super::IdN>>,
+        &mut LPO<NoSpaceWrapper<'store, super::IdN>>,
+    ),
+) -> dashmap::mapref::one::Ref<
+    'a,
+    (super::IdN, super::IdN),
+    (crate::MappingStage, mapping_store::VecStore<IdD>),
+    S,
+>
+where
+    S: BuildHasher,
+    S: Clone,
+{
+    let mappings_cache = mappings_alone;
     use hyper_diff::matchers::mapping_store::MappingStore;
     use hyper_diff::matchers::mapping_store::VecStore;
+    let hyperast = stores;
     use hyper_diff::matchers::Mapping;
+    dbg!();
+    match mappings_cache.entry((other_tr, current_tr)) {
+        dashmap::mapref::entry::Entry::Occupied(entry) => entry.into_ref().downgrade(),
+        dashmap::mapref::entry::Entry::Vacant(entry) => {
+            let mappings = VecStore::default();
+            let (src_arena, dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
+            let mut mapper = Mapper {
+                hyperast,
+                mapping: Mapping {
+                    src_arena,
+                    dst_arena,
+                    mappings,
+                },
+            };
+            mapper.mapping.mappings.topit(
+                mapper.mapping.src_arena.len(),
+                mapper.mapping.dst_arena.len(),
+            );
 
-    let hyperast = &repositories.processor.main_stores;
-    let src = &src_tr;
-    let dst = &dst_tr;
-    let now = Instant::now();
-    assert_ne!(src, dst);
-    let (mut decompress_src, mut decompress_dst) = {
-        use hyper_ast::types::DecompressedSubtree;
-        let mut cached_decomp = |id: &NodeIdentifier| -> Option<
-            dashmap::mapref::one::RefMut<NodeIdentifier, LazyPostOrder<HashedNodeRef<'a>, u32>>,
-        > {
-            let decompress = partial_comp_cache
-                .try_entry(*id)?
-                .or_insert_with(|| unsafe {
-                    std::mem::transmute(LazyPostOrder::<_, u32>::decompress(
-                        hyperast.node_store(),
-                        id,
-                    ))
-                });
-            Some(unsafe { std::mem::transmute(decompress) })
-        };
-        loop {
-            match (cached_decomp(src), cached_decomp(dst)) {
-                (Some(decompress_src), Some(decompress_dst)) => {
-                    break (decompress_src, decompress_dst)
-                }
-                (None, None) => {
-                    dbg!();
-                }
-                _ => {
-                    dbg!(
-                        partial_comp_cache.hash_usize(src),
-                        partial_comp_cache.hash_usize(dst)
-                    );
-                    dbg!(
-                        partial_comp_cache.determine_shard(partial_comp_cache.hash_usize(src)),
-                        partial_comp_cache.determine_shard(partial_comp_cache.hash_usize(dst))
-                    );
-                }
-            }
-            sleep(Duration::from_secs(2));
+            let vec_store = matching::full2(hyperast, mapper);
+
+            entry
+                .insert((crate::MappingStage::Bottomup, vec_store))
+                .downgrade()
         }
-    };
-    hyperast
-        .node_store
-        .resolve(decompress_src.original(&decompress_src.root()));
-    hyperast
-        .node_store
-        .resolve(decompress_dst.original(&decompress_dst.root()));
-
-    let mappings = VecStore::default();
-    let mut mapper = Mapper {
-        hyperast,
-        mapping: Mapping {
-            src_arena: decompress_src.value_mut(),
-            dst_arena: decompress_dst.value_mut(),
-            mappings,
-        },
-    };
-    mapper.mapping.mappings.topit(
-        mapper.mapping.src_arena.len(),
-        mapper.mapping.dst_arena.len(),
-    );
-    dbg!();
-    let mm = LazyGreedySubtreeMatcher::<
-        'a,
-        SimpleStores<TStore>,
-        &mut LazyPostOrder<HashedNodeRef<'a>, u32>,
-        &mut LazyPostOrder<HashedNodeRef<'a>, u32>,
-        VecStore<_>,
-    >::compute_multi_mapping::<DefaultMultiMappingStore<_>>(&mut mapper);
-    dbg!();
-
-    hyper_diff::matchers::Mapping {
-        src_arena: decompress_src,
-        dst_arena: decompress_dst,
-        mappings: mm,
     }
 }
 
-pub fn child_by_type<'store, HAST: HyperAST<'store, IdN = NodeIdentifier>>(
-    stores: &'store HAST,
-    d: NodeIdentifier,
-    t: &<HAST::TS as types::TypeStore<HAST::T>>::Ty,
-) -> Option<(NodeIdentifier, usize)> {
-    let n = stores.node_store().resolve(&d);
-    let s = n
-        .children()
-        .unwrap()
-        .iter_children()
-        .enumerate()
-        .find(|(_, x)| {
-            stores.resolve_type(*x).eq(t)
-        })
-        .map(|(i, x)| (*x, i));
-    s
+fn track_top_down<'store, C, P>(
+    current_tr: super::IdN,
+    other_tr: super::IdN,
+    pair: &mut (
+        &mut LPO<NoSpaceWrapper<'store, super::IdN>>,
+        &mut LPO<NoSpaceWrapper<'store, super::IdN>>,
+    ),
+    no_spaces_path_to_target: &[u16],
+    flags: &Flags,
+    target: &P,
+    with_spaces_stores: &'store SimpleStores<TStore>,
+    stores: &'store types::SimpleHyperAST<
+        NoSpaceWrapper<'store, super::IdN>,
+        &TStore,
+        no_space::NoSpaceNodeStoreWrapper<'store>,
+        &hyper_ast::store::labels::LabelStore,
+    >,
+    postprocess_matching: impl Fn(LocalPieceOfCode<super::IdN, super::Idx>) -> C,
+) -> Option<MappingResult<super::IdN, super::Idx, C>>
+where
+    P: SolvedPosition<NodeIdentifier>
+        + position_accessors::WithPreOrderOffsets<Idx = super::Idx>
+        + position_accessors::OffsetPostionT<NodeIdentifier, IdO = usize>,
+{
+    let node_store = &stores.node_store;
+    let tracker_nospace = MappingTracker3 {
+        stores: &hyper_ast_cvs_git::no_space::IntoNoSpaceGAT::as_nospaces(with_spaces_stores),
+    };
+    let mapped = {
+        let hyperast = stores;
+        let src = &current_tr;
+        let dst = &other_tr;
+        let (src_arena, dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
+        matching::top_down(hyperast, src_arena, dst_arena)
+    };
+    let (mapper_src_arena, mapper_dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
+    let mapper_mappings = &mapped;
+    let mut curr = mapper_src_arena.root();
+    let mut path = no_spaces_path_to_target;
+    let flags: EnumSet<_> = flags.into();
+    loop {
+        // dbg!(path);
+        let dsts = mapper_mappings.get_dsts(&curr);
+        let curr_flags = FlagsE::Upd | FlagsE::Child | FlagsE::SimChild; //  | FlagsE::ExactChild
+        let parent_flags = curr_flags | FlagsE::Parent | FlagsE::SimParent; //  | FlagsE::ExactParent
+        if dsts.is_empty() {
+            // continue through path_to_target
+            // dbg!(curr);
+        } else if path.len() == 0 {
+            // need to check curr node flags
+            if flags.is_subset(curr_flags) {
+                // only trigger on curr and children changed
+                let nodes = tracker_nospace.size(&current_tr, &other_tr);
+                let nodes = 500_000;
+
+                return Some(MappingResult::Skipped {
+                    nodes,
+                    src: {
+                        let (pos, path_ids) = compute_position_and_nodes(
+                            current_tr,
+                            &mut target.iter_offsets().copied(),
+                            with_spaces_stores,
+                        );
+
+                        LocalPieceOfCode::from_file_and_range(
+                            pos.file(),
+                            target.start()..target.end(),
+                            target.iter_offsets().copied().collect(),
+                            path_ids,
+                        )
+                    },
+                    next: dsts
+                        .iter()
+                        .map(|x| {
+                            assert_eq!(
+                                other_tr,
+                                mapper_dst_arena.original(&mapper_dst_arena.root())
+                            );
+                            let path_dst = mapper_dst_arena.path(&mapper_dst_arena.root(), x);
+                            let (path_dst,) = path_with_spaces(
+                                other_tr,
+                                &mut path_dst.iter().copied(),
+                                with_spaces_stores,
+                            );
+                            postprocess_matching(compute_local(
+                                other_tr,
+                                &path_dst,
+                                with_spaces_stores,
+                            ))
+                        })
+                        .collect(),
+                });
+            }
+            // also the type of src and dsts
+            // also check it file path changed
+            // can we test if parent changed ? at least we can ckeck some attributes
+        } else if path.len() == 1 {
+            // need to check parent node flags
+            if flags.is_subset(parent_flags) {
+                // only trigger on parent, curr and children changed
+                let nodes = tracker_nospace.size(&current_tr, &other_tr);
+                let nodes = 500_000;
+                return Some(MappingResult::Skipped {
+                    nodes,
+                    src: {
+                        let (pos, path_ids) = compute_position_and_nodes(
+                            current_tr,
+                            &mut target.iter_offsets().copied(),
+                            with_spaces_stores,
+                        );
+
+                        let path = target.iter_offsets().copied().collect();
+                        LocalPieceOfCode::from_position(&pos, path, path_ids)
+                    },
+                    next: dsts
+                        .iter()
+                        .map(|x| {
+                            assert_eq!(
+                                other_tr,
+                                mapper_dst_arena.original(&mapper_dst_arena.root())
+                            );
+                            let mut path_dst = mapper_dst_arena.path(&mapper_dst_arena.root(), x);
+                            path_dst.extend(path); // WARN with similarity it might not be possible to simply concat path...
+                            let (path_dst,) = path_with_spaces(
+                                other_tr,
+                                &mut path_dst.iter().copied(),
+                                with_spaces_stores,
+                            );
+                            postprocess_matching(compute_local(
+                                other_tr,
+                                &path_dst,
+                                with_spaces_stores,
+                            ))
+                        })
+                        .collect(),
+                });
+            }
+            // also the type of src and dsts
+            // also check if file path changed
+            // can we test if parent changed ? at least we can ckeck some attributes
+        } else {
+            // need to check flags, the type of src and dsts
+            if flags.is_subset(parent_flags) {
+                // only trigger on parent, curr and children changed
+                let nodes = tracker_nospace.size(&current_tr, &other_tr);
+                let nodes = 500_000;
+                return Some(MappingResult::Skipped {
+                    nodes,
+                    src: compute_local2(current_tr, target, with_spaces_stores),
+                    next: dsts
+                        .iter()
+                        .map(|x| {
+                            assert_eq!(
+                                other_tr,
+                                mapper_dst_arena.original(&mapper_dst_arena.root())
+                            );
+                            let mut path_dst = mapper_dst_arena.path(&mapper_dst_arena.root(), x);
+                            path_dst.extend(path); // WARN with similarity it might not be possible to simply concat path...
+                            let (path_dst,) = path_with_spaces(
+                                other_tr,
+                                &mut path_dst.iter().copied(),
+                                with_spaces_stores,
+                            );
+                            postprocess_matching(compute_local(
+                                other_tr,
+                                &path_dst,
+                                with_spaces_stores,
+                            ))
+                        })
+                        .collect(),
+                });
+            }
+            // also check if file path changed
+            // can we test if parent changed ? at least we can ckeck some attributes
+        }
+
+        let Some(i) = path.get(0) else {
+            break;
+        };
+        path = &path[1..];
+        let cs = mapper_src_arena.decompress_children(node_store, &curr);
+        if cs.is_empty() {
+            break;
+        }
+        curr = cs[*i as usize];
+    }
+    None
+}
+
+fn compute_local(
+    tr: super::IdN,
+    path: &[super::Idx],
+    with_spaces_stores: &SimpleStores<TStore>,
+) -> LocalPieceOfCode<super::IdN, super::Idx> {
+    let (pos, path_ids) =
+        compute_position_and_nodes(tr, &mut path.iter().copied(), with_spaces_stores);
+    let path = path.to_vec();
+    LocalPieceOfCode::from_position(&pos, path, path_ids)
+}
+
+fn compute_local2(
+    tr: super::IdN,
+    path: &impl position_accessors::WithPreOrderOffsets<Idx = super::Idx>,
+    with_spaces_stores: &SimpleStores<TStore>,
+) -> LocalPieceOfCode<super::IdN, super::Idx> {
+    let (pos, path_ids) =
+        compute_position_and_nodes(tr, &mut path.iter_offsets().copied(), with_spaces_stores);
+    let path = path.iter_offsets().copied().collect();
+    LocalPieceOfCode::from_position(&pos, path, path_ids)
 }

--- a/client/src/track/compute.rs
+++ b/client/src/track/compute.rs
@@ -117,7 +117,11 @@ where
         // case where
         let subtree_mappings = {
             let hyperast = stores;
-            matching::top_down(hyperast, &mut mapper.mapping.src_arena, &mut mapper.mapping.dst_arena)
+            matching::top_down(
+                hyperast,
+                &mut mapper.mapping.src_arena,
+                &mut mapper.mapping.dst_arena,
+            )
         };
         dbg!();
         if let Some(value) = track_greedy(
@@ -132,12 +136,7 @@ where
         ) {
             return value;
         }
-        compute_mappings_full(
-            stores,
-            mappings_alone,
-            &mut mapper,
-            Some(subtree_mappings),
-        )
+        compute_mappings_full(stores, mappings_alone, &mut mapper, Some(subtree_mappings))
     } else {
         compute_mappings_full(stores, mappings_alone, &mut mapper, None)
     };
@@ -164,11 +163,12 @@ where
         );
     }
     let Mapper {
-        mapping: hyper_diff::matchers::Mapping {
-            src_arena: src_tree,
-            dst_arena: dst_tree,
-            ..
-        },
+        mapping:
+            hyper_diff::matchers::Mapping {
+                src_arena: src_tree,
+                dst_arena: dst_tree,
+                ..
+            },
         ..
     } = mapper;
 
@@ -402,7 +402,10 @@ fn compute_mappings_full<'store, 'alone, 'trees, 'mapper, 'rest>(
 
             matching::bottom_up_hiding(hyperast, &mm, mapper);
 
-            let value = (crate::MappingStage::Bottomup, mapper.mapping.mappings.clone());
+            let value = (
+                crate::MappingStage::Bottomup,
+                mapper.mapping.mappings.clone(),
+            );
             entry.insert(value).downgrade()
         }
     }
@@ -459,14 +462,14 @@ where
                     src: {
                         let (pos, path_ids) = compute_position_and_nodes(
                             current_tr,
-                            &mut target.iter_offsets().copied(),
+                            &mut target.iter_offsets(),
                             with_spaces_stores,
                         );
 
                         LocalPieceOfCode::from_file_and_range(
                             pos.file(),
                             target.start()..target.end(),
-                            target.iter_offsets().copied().collect(),
+                            target.iter_offsets().collect(),
                             path_ids,
                         )
                     },
@@ -502,11 +505,11 @@ where
                     src: {
                         let (pos, path_ids) = compute_position_and_nodes(
                             current_tr,
-                            &mut target.iter_offsets().copied(),
+                            &mut target.iter_offsets(),
                             with_spaces_stores,
                         );
 
-                        let path = target.iter_offsets().copied().collect();
+                        let path = target.iter_offsets().collect();
                         LocalPieceOfCode::from_position(&pos, path, path_ids)
                     },
                     next: dsts
@@ -594,8 +597,8 @@ fn compute_local2(
 ) -> LocalPieceOfCode<super::IdN, super::Idx> {
     let tr = path.root();
     let (pos, path_ids) =
-        compute_position_and_nodes(tr, &mut path.iter_offsets().copied(), with_spaces_stores);
-    let path = path.iter_offsets().copied().collect();
+        compute_position_and_nodes(tr, &mut path.iter_offsets(), with_spaces_stores);
+    let path = path.iter_offsets().collect();
     LocalPieceOfCode::from_position(&pos, path, path_ids)
 }
 

--- a/client/src/track/compute.rs
+++ b/client/src/track/compute.rs
@@ -1,0 +1,1270 @@
+
+fn aux_aux(
+    repo_handle: &impl ConfiguredRepoTrait,
+    src_tr: NodeIdentifier,
+    dst_tr: NodeIdentifier,
+    path_to_target: Vec<u16>,
+    no_spaces_path_to_target: Vec<u16>,
+    flags: &Flags,
+    start: usize,
+    end: usize,
+    partial_decomps: &PartialDecompCache,
+    mappings_alone: &MappingAloneCache,
+    repositories: std::sync::RwLockReadGuard<multi_preprocessed::PreProcessedRepositories>,
+    dst_oid: hyper_ast_cvs_git::git::Oid,
+    target_node: NodeIdentifier,
+) -> MappingResult {
+    let with_spaces_stores = &repositories.processor.main_stores;
+    let stores = &no_space::as_nospaces(with_spaces_stores);
+    let node_store = &stores.node_store;
+    // NOTE: persists mappings, could also easily persist diffs,
+    // but some compression on mappins could help
+    // such as, not storing the decompression arenas
+    // or encoding mappings more efficiently considering that most slices could simply by represented as ranges (ie. mapped identical subtrees)
+    // let mapper = lazy_mapping(repos, &mut state.mappings, src_tr, dst_tr);
+
+    dbg!(src_tr, dst_tr);
+    if src_tr == dst_tr {
+        let src_size = stores.node_store.resolve(src_tr).size();
+        let dst_size = stores.node_store.resolve(dst_tr).size();
+        let nodes = src_size + dst_size;
+        let (pos, path_ids) = compute_position_and_nodes(
+            dst_tr,
+            &mut path_to_target.iter().copied(),
+            with_spaces_stores,
+        );
+        dbg!();
+        let range = pos.range();
+        let matches = vec![PieceOfCode {
+            user: repo_handle.spec().user.clone(),
+            name: repo_handle.spec().name.clone(),
+            commit: dst_oid.to_string(),
+            file: pos.file().to_str().unwrap().to_string(),
+            start: range.start,
+            end: range.end,
+            path: path_to_target.iter().map(|x| *x as usize).collect(),
+            path_ids: path_ids.clone(),
+        }];
+        let src = LocalPieceOfCode {
+            file: pos.file().to_string_lossy().to_string(),
+            start,
+            end,
+            path: path_to_target.iter().map(|x| *x as usize).collect(),
+            path_ids,
+        };
+        if flags.some() {
+            return MappingResult::Skipped {
+                nodes,
+                src,
+                next: matches,
+            };
+        } else {
+            return MappingResult::Direct { src, matches };
+        }
+    }
+    let pair = get_pair_simp(partial_decomps, stores, &src_tr, &dst_tr);
+
+    if flags.some() {
+        dbg!();
+
+        let mapped = {
+            let mappings_cache = mappings_alone;
+            let hyperast = stores;
+            let src = &src_tr;
+            let dst = &dst_tr;
+            let (src_arena, dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
+            matching::top_down(hyperast, src_arena, dst_arena)
+        };
+        let (mapper_src_arena, mapper_dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
+        let mapper_mappings = &mapped;
+        let mut curr = mapper_src_arena.root();
+        let mut path = &no_spaces_path_to_target[..];
+        let flags: EnumSet<_> = flags.into();
+        loop {
+            dbg!(path);
+            let dsts = mapper_mappings.get_dsts(&curr);
+            let curr_flags = FlagsE::Upd | FlagsE::Child | FlagsE::SimChild; //  | FlagsE::ExactChild
+            let parent_flags = curr_flags | FlagsE::Parent | FlagsE::SimParent; //  | FlagsE::ExactParent
+            if dsts.is_empty() {
+                // continue through path_to_target
+                dbg!(curr);
+            } else if path.len() == 0 {
+                // need to check curr node flags
+                if flags.is_subset(curr_flags) {
+                    // only trigger on curr and children changed
+
+                    let src_size = stores.node_store.resolve(src_tr).size();
+                    let dst_size = stores.node_store.resolve(dst_tr).size();
+                    let nodes = src_size + dst_size;
+                    let nodes = 500_000;
+
+                    return MappingResult::Skipped {
+                        nodes,
+                        src: {
+                            let (pos, path_ids) = compute_position_and_nodes(
+                                src_tr,
+                                &mut path_to_target.iter().copied(),
+                                with_spaces_stores,
+                            );
+
+                            LocalPieceOfCode {
+                                file: pos.file().to_string_lossy().to_string(),
+                                start,
+                                end,
+                                path: path_to_target.iter().map(|x| *x as usize).collect(),
+                                path_ids,
+                            }
+                        },
+                        next: dsts
+                            .iter()
+                            .map(|x| {
+                                let path_dst = mapper_dst_arena.path(&mapper_dst_arena.root(), x);
+                                let (path_dst,) = path_with_spaces(
+                                    dst_tr,
+                                    &mut path_dst.iter().copied(),
+                                    &repositories.processor.main_stores,
+                                );
+                                let (pos, path_ids) = compute_position_and_nodes(
+                                    dst_tr,
+                                    &mut path_dst.iter().copied(),
+                                    with_spaces_stores,
+                                );
+                                let range = pos.range();
+                                PieceOfCode {
+                                    user: repo_handle.spec().user.clone(),
+                                    name: repo_handle.spec().name.clone(),
+                                    commit: dst_oid.to_string(),
+                                    file: pos.file().to_str().unwrap().to_string(),
+                                    start: range.start,
+                                    end: range.end,
+                                    path: path_dst.iter().map(|x| *x as usize).collect(),
+                                    path_ids,
+                                }
+                            })
+                            .collect(),
+                    };
+                }
+                // also the type of src and dsts
+                // also check it file path changed
+                // can we test if parent changed ? at least we can ckeck some attributes
+            } else if path.len() == 1 {
+                // need to check parent node flags
+                if flags.is_subset(parent_flags) {
+                    // only trigger on parent, curr and children changed
+                    let src_size = stores.node_store.resolve(src_tr).size();
+                    let dst_size = stores.node_store.resolve(dst_tr).size();
+                    let nodes = src_size + dst_size;
+                    let nodes = 500_000;
+                    return MappingResult::Skipped {
+                        nodes,
+                        src: {
+                            let (pos, path_ids) = compute_position_and_nodes(
+                                src_tr,
+                                &mut path_to_target.iter().copied(),
+                                with_spaces_stores,
+                            );
+
+                            LocalPieceOfCode {
+                                file: pos.file().to_string_lossy().to_string(),
+                                start,
+                                end,
+                                path: path_to_target.iter().map(|x| *x as usize).collect(),
+                                path_ids,
+                            }
+                        },
+                        next: dsts
+                            .iter()
+                            .map(|x| {
+                                let mut path_dst =
+                                    mapper_dst_arena.path(&mapper_dst_arena.root(), x);
+                                path_dst.extend(path); // WARN with similarity it might not be possible to simply concat path...
+                                let (path_dst,) = path_with_spaces(
+                                    dst_tr,
+                                    &mut path_dst.iter().copied(),
+                                    &repositories.processor.main_stores,
+                                );
+                                let (pos, path_ids) = compute_position_and_nodes(
+                                    dst_tr,
+                                    &mut path_dst.iter().copied(),
+                                    with_spaces_stores,
+                                );
+                                let range = pos.range();
+                                PieceOfCode {
+                                    user: repo_handle.spec().user.clone(),
+                                    name: repo_handle.spec().name.clone(),
+                                    commit: dst_oid.to_string(),
+                                    file: pos.file().to_str().unwrap().to_string(),
+                                    start: range.start,
+                                    end: range.end,
+                                    path: path_dst.iter().map(|x| *x as usize).collect(),
+                                    path_ids,
+                                }
+                            })
+                            .collect(),
+                    };
+                }
+                // also the type of src and dsts
+                // also check if file path changed
+                // can we test if parent changed ? at least we can ckeck some attributes
+            } else {
+                // need to check flags, the type of src and dsts
+                if flags.is_subset(parent_flags) {
+                    // only trigger on parent, curr and children changed
+                    let src_size = stores.node_store.resolve(src_tr).size();
+                    let dst_size = stores.node_store.resolve(dst_tr).size();
+                    let nodes = src_size + dst_size;
+                    let nodes = 500_000;
+                    return MappingResult::Skipped {
+                        nodes,
+                        src: {
+                            let (pos, path_ids) = compute_position_and_nodes(
+                                src_tr,
+                                &mut path_to_target.iter().copied(),
+                                with_spaces_stores,
+                            );
+
+                            LocalPieceOfCode {
+                                file: pos.file().to_string_lossy().to_string(),
+                                start,
+                                end,
+                                path: path_to_target.iter().map(|x| *x as usize).collect(),
+                                path_ids,
+                            }
+                        },
+                        next: dsts
+                            .iter()
+                            .map(|x| {
+                                let mut path_dst =
+                                    mapper_dst_arena.path(&mapper_dst_arena.root(), x);
+                                path_dst.extend(path); // WARN with similarity it might not be possible to simply concat path...
+                                let (path_dst,) = path_with_spaces(
+                                    dst_tr,
+                                    &mut path_dst.iter().copied(),
+                                    &repositories.processor.main_stores,
+                                );
+                                let (pos, path_ids) = compute_position_and_nodes(
+                                    dst_tr,
+                                    &mut path_dst.iter().copied(),
+                                    with_spaces_stores,
+                                );
+                                let range = pos.range();
+                                PieceOfCode {
+                                    user: repo_handle.spec().user.clone(),
+                                    name: repo_handle.spec().name.clone(),
+                                    commit: dst_oid.to_string(),
+                                    file: pos.file().to_str().unwrap().to_string(),
+                                    start: range.start,
+                                    end: range.end,
+                                    path: path_dst.iter().map(|x| *x as usize).collect(),
+                                    path_ids,
+                                }
+                            })
+                            .collect(),
+                    };
+                }
+                // also check if file path changed
+                // can we test if parent changed ? at least we can ckeck some attributes
+            }
+
+            let Some(i) = path.get(0) else {
+                break;
+            };
+            path = &path[1..];
+            let cs = mapper_src_arena.decompress_children(node_store, &curr);
+            if cs.is_empty() {
+                break;
+            }
+            curr = cs[*i as usize];
+        }
+    }
+
+    let mapped = {
+        let mappings_cache = mappings_alone;
+        use hyper_diff::matchers::mapping_store::MappingStore;
+        use hyper_diff::matchers::mapping_store::VecStore;
+        let hyperast = stores;
+        use hyper_diff::matchers::Mapping;
+
+        dbg!();
+        match mappings_cache.entry((src_tr, dst_tr)) {
+            dashmap::mapref::entry::Entry::Occupied(entry) => entry.into_ref().downgrade(),
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                let mappings = VecStore::default();
+                let (src_arena, dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
+                dbg!(src_arena.len());
+                dbg!(dst_arena.len());
+                let src_size = stores.node_store.resolve(src_tr).size();
+                let dst_size = stores.node_store.resolve(dst_tr).size();
+                dbg!(src_size);
+                dbg!(dst_size);
+                let mut mapper = Mapper {
+                    hyperast,
+                    mapping: Mapping {
+                        src_arena,
+                        dst_arena,
+                        mappings,
+                    },
+                };
+                dbg!();
+                dbg!(mapper.mapping.src_arena.len());
+                dbg!(mapper.mapping.dst_arena.len());
+                mapper.mapping.mappings.topit(
+                    mapper.mapping.src_arena.len(),
+                    mapper.mapping.dst_arena.len(),
+                );
+                dbg!();
+
+                let vec_store = matching::full2(hyperast, mapper);
+
+                dbg!();
+                entry
+                    .insert((crate::MappingStage::Bottomup, vec_store))
+                    .downgrade()
+            }
+        }
+    };
+    let (mapper_src_arena, mapper_dst_arena) = (pair.0.get_mut(), pair.1.get_mut());
+    let mapper_mappings = &mapped.1;
+    let root = mapper_src_arena.root();
+    let mapping_target =
+        mapper_src_arena.child_decompressed(node_store, &root, &no_spaces_path_to_target);
+
+    let mut matches = vec![];
+    if let Some(mapped) = mapper_mappings.get_dst(&mapping_target) {
+        let mapped = mapper_dst_arena.decompress_to(node_store, &mapped);
+        let path = mapper_dst_arena.path(&mapper_dst_arena.root(), &mapped);
+        let mut path_ids = vec![mapper_dst_arena.original(&mapped)];
+        mapper_dst_arena
+            .parents(mapped)
+            .map(|i| mapper_dst_arena.original(&i))
+            .collect_into(&mut path_ids);
+        path_ids.pop();
+        assert_eq!(path.len(), path_ids.len());
+        let (path,) = path_with_spaces(
+            dst_tr,
+            &mut path.iter().copied(),
+            &repositories.processor.main_stores,
+        );
+        let (pos, mapped_node) =
+            compute_position(dst_tr, &mut path.iter().copied(), with_spaces_stores);
+        dbg!(&pos);
+        dbg!(&mapped_node);
+        let mut flagged = false;
+        let mut triggered = false;
+        if flags.exact_child {
+            flagged = true;
+            dbg!();
+            triggered |= target_node != mapped_node;
+        }
+        if flags.child || flags.sim_child {
+            flagged = true;
+            dbg!();
+
+            let target_node = stores.node_store.resolve(target_node);
+            let mapped_node = stores.node_store.resolve(mapped_node);
+            if flags.sim_child {
+                triggered |= target_node.hash(&types::HashKind::structural())
+                    != mapped_node.hash(&types::HashKind::structural());
+            } else {
+                triggered |= target_node.hash(&types::HashKind::label())
+                    != mapped_node.hash(&types::HashKind::label());
+            }
+        }
+        if flags.upd {
+            flagged = true;
+            dbg!();
+            // TODO need role name
+            // let target_ident = child_by_type(stores, target_node, &Type::Identifier);
+            // let mapped_ident = child_by_type(stores, mapped_node, &Type::Identifier);
+            // if let (Some(target_ident), Some(mapped_ident)) = (target_ident, mapped_ident) {
+            //     let target_node = stores.node_store.resolve(target_ident.0);
+            //     let target_ident = target_node.try_get_label();
+            //     let mapped_node = stores.node_store.resolve(mapped_ident.0);
+            //     let mapped_ident = mapped_node.try_get_label();
+            //     triggered |= target_ident != mapped_ident;
+            // }
+        }
+        if flags.parent {
+            flagged = true;
+            dbg!();
+
+            let target_parent = mapper_src_arena.parent(&mapping_target);
+            let target_parent = target_parent.map(|x| mapper_src_arena.original(&x));
+            let mapped_parent = mapper_dst_arena.parent(&mapped);
+            let mapped_parent = mapped_parent.map(|x| mapper_dst_arena.original(&x));
+            triggered |= target_parent != mapped_parent;
+        }
+        // if flags.meth {
+        //     flagged = true;
+        //     dbg!();
+        // }
+        // if flags.typ {
+        //     flagged = true;
+        //     dbg!();
+        // }
+        // if flags.top {
+        //     flagged = true;
+        //     dbg!();
+        // }
+        // if flags.file {
+        //     flagged = true;
+        //     dbg!();
+        // }
+        // if flags.pack {
+        //     flagged = true;
+        //     dbg!();
+        // }
+        // TODO add flags for artefacts (tests, prod code, build, lang, misc)
+        // TODO add flags for similarity comps
+        let range = pos.range();
+        matches.push(PieceOfCode {
+            user: repo_handle.spec().user.clone(),
+            name: repo_handle.spec().name.clone(),
+            commit: dst_oid.to_string(),
+            file: pos.file().to_str().unwrap().to_string(),
+            start: range.start,
+            end: range.end,
+            path: path.iter().map(|x| *x as usize).collect(),
+            path_ids: path_ids.clone(),
+        });
+        if flagged && !triggered {
+            use hyper_ast::types::WithStats;
+            let src_size = stores.node_store.resolve(src_tr).size();
+            let dst_size = stores.node_store.resolve(dst_tr).size();
+            let nodes = src_size + dst_size;
+            return MappingResult::Skipped {
+                nodes,
+                src: {
+                    let (pos, path_ids) = compute_position_and_nodes(
+                        src_tr,
+                        &mut path_to_target.iter().copied(),
+                        with_spaces_stores,
+                    );
+
+                    LocalPieceOfCode {
+                        file: pos.file().to_string_lossy().to_string(),
+                        start,
+                        end,
+                        path: path_to_target.iter().map(|x| *x as usize).collect(),
+                        path_ids,
+                    }
+                },
+                next: matches,
+            };
+        }
+        let path = path_to_target.iter().map(|x| *x as usize).collect();
+        let (target_pos, target_path_ids) = compute_position_and_nodes(
+            src_tr,
+            &mut path_to_target.iter().copied(),
+            with_spaces_stores,
+        );
+        return MappingResult::Direct {
+            src: LocalPieceOfCode {
+                file: target_pos.file().to_string_lossy().to_string(),
+                start,
+                end,
+                path,
+                path_ids: target_path_ids,
+            },
+            matches,
+        };
+    }
+
+    for parent_target in mapper_src_arena.parents(mapping_target) {
+        if let Some(mapped_parent) = mapper_mappings.get_dst(&parent_target) {
+            let mapped_parent = mapper_dst_arena.decompress_to(node_store, &mapped_parent);
+            let path = mapper_dst_arena.path(&mapper_dst_arena.root(), &mapped_parent);
+            let mut path_ids = vec![mapper_dst_arena.original(&mapped_parent)];
+            mapper_dst_arena
+                .parents(mapped_parent)
+                .map(|i| mapper_dst_arena.original(&i))
+                .collect_into(&mut path_ids);
+            path_ids.pop();
+            assert_eq!(path.len(), path_ids.len());
+            let (path,) = path_with_spaces(
+                dst_tr,
+                &mut path.iter().copied(),
+                &repositories.processor.main_stores,
+            );
+            let (pos, mapped_node) =
+                compute_position(dst_tr, &mut path.iter().copied(), with_spaces_stores);
+            dbg!(&pos);
+            dbg!(&mapped_node);
+            let range = pos.range();
+            let fallback = PieceOfCode {
+                user: repo_handle.spec().user.clone(),
+                name: repo_handle.spec().name.clone(),
+                commit: dst_oid.to_string(),
+                file: pos.file().to_str().unwrap().to_string(),
+                start: range.start,
+                end: range.end,
+                path: path.iter().map(|x| *x as usize).collect(),
+                path_ids: path_ids.clone(),
+            };
+
+            let src = {
+                let path = path_to_target.iter().map(|x| *x as usize).collect();
+                let (target_pos, target_path_ids) = compute_position_and_nodes(
+                    src_tr,
+                    &mut path_to_target.iter().copied(),
+                    with_spaces_stores,
+                );
+                LocalPieceOfCode {
+                    file: target_pos.file().to_string_lossy().to_string(),
+                    start,
+                    end,
+                    path,
+                    path_ids: target_path_ids,
+                }
+            };
+            return MappingResult::Missing { src, fallback };
+        };
+    }
+    let path = path_to_target.iter().map(|x| *x as usize).collect();
+    let (target_pos, target_path_ids) = compute_position_and_nodes(
+        src_tr,
+        &mut path_to_target.iter().copied(),
+        with_spaces_stores,
+    );
+    // TODO what should be done if there is no match ?
+    MappingResult::Direct {
+        src: LocalPieceOfCode {
+            file: target_pos.file().to_string_lossy().to_string(),
+            start,
+            end,
+            path,
+            path_ids: target_path_ids,
+        },
+        matches,
+    }
+}
+
+// fn diff<'a>(
+//     repositories: &'a multi_preprocessed::PreProcessedRepositories,
+//     mappings: &'a mut crate::MappingCache,
+//     src_tr: NodeIdentifier,
+//     dst_tr: NodeIdentifier,
+// ) -> &'a hyper_diff::matchers::Mapping<
+//     hyper_diff::decompressed_tree_store::CompletePostOrder<
+//         hyper_ast::store::nodes::legion::HashedNodeRef<'a>,
+//         u32,
+//     >,
+//     hyper_diff::decompressed_tree_store::CompletePostOrder<
+//         hyper_ast::store::nodes::legion::HashedNodeRef<'a>,
+//         u32,
+//     >,
+//     hyper_diff::matchers::mapping_store::VecStore<u32>,
+// > {
+//     use hyper_diff::decompressed_tree_store::CompletePostOrder;
+//     let mapped = mappings.entry((src_tr, dst_tr)).or_insert_with(|| {
+//         hyper_diff::algorithms::gumtree_lazy::diff(
+//             &repositories.processor.main_stores,
+//             &src_tr,
+//             &dst_tr,
+//         )
+//         .mapper
+//         .persist()
+//     });
+//     unsafe { Mapper::<_,CompletePostOrder<_,_>,CompletePostOrder<_,_>,_>::unpersist(&repositories.processor.main_stores, &*mapped) }
+// }
+
+// WARN lazy subtrees are not complete
+fn lazy_mapping<'a>(
+    repositories: &'a multi_preprocessed::PreProcessedRepositories,
+    mappings: &'a crate::MappingCache,
+    src_tr: NodeIdentifier,
+    dst_tr: NodeIdentifier,
+) -> dashmap::mapref::one::RefMut<
+    'a,
+    (NodeIdentifier, NodeIdentifier),
+    hyper_diff::matchers::Mapping<
+        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
+            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
+            u32,
+        >,
+        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
+            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
+            u32,
+        >,
+        hyper_diff::matchers::mapping_store::VecStore<u32>,
+    >,
+> {
+    use hyper_ast::types::HyperAST;
+    use hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder;
+    use hyper_diff::matchers::heuristic::gt::{
+        lazy2_greedy_bottom_up_matcher::GreedyBottomUpMatcher,
+        lazy2_greedy_subtree_matcher::LazyGreedySubtreeMatcher,
+    };
+    use hyper_diff::matchers::mapping_store::DefaultMultiMappingStore;
+    use hyper_diff::matchers::mapping_store::MappingStore;
+    use hyper_diff::matchers::mapping_store::VecStore;
+    let mapped = mappings.entry((src_tr, dst_tr)).or_insert_with(|| {
+        let hyperast = &repositories.processor.main_stores;
+        let src = &src_tr;
+        let dst = &dst_tr;
+        let now = Instant::now();
+        let mapper: Mapper<_, LazyPostOrder<_, u32>, LazyPostOrder<_, u32>, VecStore<_>> =
+            hyperast.decompress_pair(src, dst).into();
+        let subtree_prepare_t = now.elapsed().as_secs_f64();
+        let now = Instant::now();
+        let mapper =
+            LazyGreedySubtreeMatcher::<_, _, _, _>::match_it::<DefaultMultiMappingStore<_>>(mapper);
+        let subtree_matcher_t = now.elapsed().as_secs_f64();
+        let subtree_mappings_s = mapper.mappings().len();
+        dbg!(&subtree_matcher_t, &subtree_mappings_s);
+        let bottomup_prepare_t = 0.;
+        let now = Instant::now();
+        let mapper = GreedyBottomUpMatcher::<_, _, _, _, VecStore<_>>::match_it(mapper);
+        dbg!(&now.elapsed().as_secs_f64());
+        let bottomup_matcher_t = now.elapsed().as_secs_f64();
+        let bottomup_mappings_s = mapper.mappings().len();
+        dbg!(&bottomup_matcher_t, &bottomup_mappings_s);
+        // let now = Instant::now();
+
+        // NOTE could also have completed trees
+        // let node_store = hyperast.node_store();
+        // let mapper = mapper.map(
+        //     |src_arena| CompletePostOrder::from(src_arena.complete(node_store)),
+        //     |dst_arena| {
+        //         let complete = CompletePostOrder::from(dst_arena.complete(node_store));
+        //         SimpleBfsMapper::from(node_store, complete)
+        //     },
+        // );
+
+        // NOTE we do not use edit scripts here
+        // let prepare_gen_t = now.elapsed().as_secs_f64();
+        // let now = Instant::now();
+        // let actions = ScriptGenerator::compute_actions(mapper.hyperast, &mapper.mapping).ok();
+        // let gen_t = now.elapsed().as_secs_f64();
+        // dbg!(gen_t);
+        // let mapper = mapper.map(|x| x, |dst_arena| dst_arena.back);
+        Mapper::<_, LazyPostOrder<_, _>, LazyPostOrder<_, _>, _>::persist(mapper)
+    });
+    pub unsafe fn unpersist<'a>(
+        _hyperast: &'a SimpleStores<TStore>,
+        p: dashmap::mapref::one::RefMut<
+            'a,
+            (NodeIdentifier, NodeIdentifier),
+            hyper_diff::matchers::Mapping<
+                LazyPostOrder<
+                    hyper_diff::decompressed_tree_store::PersistedNode<NodeIdentifier>,
+                    u32,
+                >,
+                LazyPostOrder<
+                    hyper_diff::decompressed_tree_store::PersistedNode<NodeIdentifier>,
+                    u32,
+                >,
+                VecStore<u32>,
+            >,
+        >,
+    ) -> dashmap::mapref::one::RefMut<
+        'a,
+        (NodeIdentifier, NodeIdentifier),
+        hyper_diff::matchers::Mapping<
+            LazyPostOrder<HashedNodeRef<'a, NodeIdentifier>, u32>,
+            LazyPostOrder<HashedNodeRef<'a, NodeIdentifier>, u32>,
+            VecStore<u32>,
+        >,
+    > {
+        unsafe { std::mem::transmute(p) }
+    }
+    unsafe { unpersist(&repositories.processor.main_stores, mapped) }
+}
+
+struct RRR<'a>(
+    dashmap::mapref::one::Ref<
+        'a,
+        (NodeIdentifier, NodeIdentifier),
+        (
+            crate::MappingStage,
+            hyper_diff::matchers::mapping_store::VecStore<u32>,
+        ),
+    >,
+);
+
+mod my_dash {
+    use std::{
+        cell::UnsafeCell,
+        collections::hash_map::RandomState,
+        fmt::Debug,
+        hash::{BuildHasher, Hash},
+    };
+
+    use dashmap::{DashMap, RwLockWriteGuard, SharedValue};
+    use hashbrown::HashMap;
+
+    // pub fn entries<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone>(
+    //     map: DashMap<K, V, S>,
+    //     key1: K,
+    //     key2: K,
+    // ) -> Entry<'a, K, V, S> {
+    //     let hash = map.hash_usize(&key1);
+
+    //     let idx = map.determine_shard(hash);
+
+    //     let shard: RwLockWriteGuard<HashMap<K, SharedValue<V>, S>> = unsafe {
+    //         debug_assert!(idx < map.shards().len());
+
+    //         map.shards().get_unchecked(idx).write()
+    //     };
+
+    //     #[repr(transparent)]
+    //     struct MySharedValue<T> {
+    //         value: UnsafeCell<T>,
+    //     }
+
+    //     impl<T> MySharedValue<T> {
+    //         /// Get a mutable raw pointer to the underlying value
+    //         fn as_ptr(&self) -> *mut T {
+    //             self.value.get()
+    //         }
+    //     }
+    //     // SAFETY: Sharded and UnsafeCell are transparent wrappers of V
+    //     let shard: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard) };
+    //     if let Some((kptr, vptr)) = shard.get_key_value(&key1) {
+    //         unsafe {
+    //             let kptr: *const K = kptr;
+    //             // SAFETY: same memory layout because transparent and same fields
+    //             let vptr: &MySharedValue<V> = std::mem::transmute(&vptr);
+    //             let vptr: *mut V = vptr.as_ptr();
+    //             Entry::Occupied(OccupiedEntry::new(shard, key1, (kptr, vptr)))
+    //         }
+    //     } else {
+    //         unsafe {
+    //             // SAFETY: same memory layout because transparent and same fields
+    //             let shard: RwLockWriteGuard<HashMap<K, V, S>> = std::mem::transmute(shard);
+    //             Entry::Vacant(VacantEntry::new(shard, key1))
+    //         }
+    //     }
+    pub fn entries<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone>(
+        map: &'a DashMap<K, V, S>,
+        key1: K,
+        key2: K,
+    ) -> Entry<'a, K, V, S> {
+        assert!(key1 != key2, "keys should be different");
+        let hash1 = map.hash_usize(&key1);
+        let idx1 = map.determine_shard(hash1);
+        let hash2 = map.hash_usize(&key2);
+        let idx2 = map.determine_shard(hash2);
+
+        if idx1 == idx2 {
+            let shard = unsafe {
+                debug_assert!(idx1 < map.shards().len());
+                debug_assert!(idx2 < map.shards().len());
+                map.shards().get_unchecked(idx1).write()
+            };
+            // SAFETY: Sharded and UnsafeCell are transparent wrappers of V
+            let shard: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard) };
+            let elem1 = shard
+                .get_key_value(&key1)
+                .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
+            let elem2 = shard
+                .get_key_value(&key2)
+                .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
+            Entry {
+                shard1: shard,
+                shard2: None,
+                key1,
+                key2,
+                elem1,
+                elem2,
+            }
+        } else {
+            let (shard1, shard2) = unsafe {
+                debug_assert!(idx1 < map.shards().len());
+                debug_assert!(idx2 < map.shards().len());
+                (
+                    map.shards().get_unchecked(idx1).write(),
+                    map.shards().get_unchecked(idx2).write(),
+                )
+            };
+            let shard1: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard1) };
+            let shard2: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard2) };
+            let elem1 = shard1
+                .get_key_value(&key1)
+                .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
+            let elem2 = shard2
+                .get_key_value(&key2)
+                .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
+            Entry {
+                shard1: shard1,
+                shard2: Some(shard2),
+                key1,
+                key2,
+                elem1,
+                elem2,
+            }
+        }
+    }
+
+    unsafe fn as_ptr<'a, K: 'a + Eq + Hash, V: 'a>(kptr1: &K, vptr1: &V) -> (*const K, *mut V) {
+        let kptr1: *const K = kptr1;
+        // SAFETY: same memory layout because transparent and same fields
+        let vptr1: &MySharedValue<V> = std::mem::transmute(&vptr1);
+        let vptr1: *mut V = vptr1.as_ptr();
+        (kptr1, vptr1)
+    }
+
+    pub(super) unsafe fn shard_as_ptr<'a, V: 'a>(vptr1: &SharedValue<V>) -> *mut V {
+        // SAFETY: same memory layout because transparent and same fields
+        let vptr1: &MySharedValue<V> = std::mem::transmute(&vptr1);
+        let vptr1: *mut V = vptr1.as_ptr();
+        vptr1
+    }
+
+    pub(super) unsafe fn shard_as_ptr2<'a, V: 'a>(vptr1: &V) -> *mut V {
+        // SAFETY: same memory layout because transparent and same fields
+        let vptr1: &MySharedValue<V> = std::mem::transmute(&vptr1);
+        let vptr1: *mut V = vptr1.as_ptr();
+        vptr1
+    }
+
+    #[repr(transparent)]
+    struct MySharedValue<T> {
+        value: UnsafeCell<T>,
+    }
+
+    impl<T> MySharedValue<T> {
+        /// Get a mutable raw pointer to the underlying value
+        fn as_ptr(&self) -> *mut T {
+            self.value.get()
+        }
+    }
+    pub struct Entry<'a, K, V, S = RandomState> {
+        shard1: RwLockWriteGuard<'a, HashMap<K, V, S>>,
+        shard2: Option<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
+        elem1: Option<(*const K, *mut V)>,
+        elem2: Option<(*const K, *mut V)>,
+        key1: K,
+        key2: K,
+    }
+    unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Send for Entry<'a, K, V, S> {}
+    unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Sync for Entry<'a, K, V, S> {}
+
+    impl<'a, K: Clone + Eq + Hash + Debug, V: Debug, S: BuildHasher> Entry<'a, K, V, S> {
+        pub fn or_insert_with(
+            self,
+            value: impl FnOnce((Option<()>, Option<()>)) -> (Option<V>, Option<V>),
+        ) -> RefMut<'a, K, V, S> {
+            match self {
+                Entry {
+                    shard1,
+                    shard2,
+                    elem1: Some((k1, v1)),
+                    elem2: Some((k2, v2)),
+                    ..
+                } => {
+                    dbg!(v1);
+                    dbg!(v2);
+                    RefMut {
+                        guard1: shard1,
+                        guard2: shard2,
+                        k1,
+                        k2,
+                        v1,
+                        v2,
+                    }
+                }
+                Entry {
+                    mut shard1,
+                    shard2: None,
+                    elem1,
+                    elem2,
+                    key1,
+                    key2,
+                } => {
+                    let (r1, r2) = value((elem1.as_ref().map(|_| ()), elem2.as_ref().map(|_| ())));
+                    let k1 = key1.clone();
+                    let k2 = key2.clone();
+                    if elem1.is_none() {
+                        let value = r1.expect("some value");
+                        let key = key1;
+                        let shard = &mut shard1;
+                        insert2_p1(key, shard, value)
+                    }
+                    if elem2.is_none() {
+                        let value = r2.expect("some value");
+                        let key = key2;
+                        let shard = &mut shard1;
+                        insert2_p1(key, shard, value)
+                    }
+                    let (k1, v1) = elem1.unwrap_or_else(|| {
+                        let shard = &mut shard1;
+                        insert2_p2(&k1, shard)
+                    });
+                    let (k2, v2) = elem2.unwrap_or_else(|| {
+                        let shard = &mut shard1;
+                        insert2_p2(&k2, shard)
+                    });
+                    dbg!(v1);
+                    dbg!(v2);
+                    RefMut {
+                        guard1: shard1,
+                        guard2: None,
+                        k1,
+                        k2,
+                        v1,
+                        v2,
+                    }
+                }
+                Entry {
+                    mut shard1,
+                    shard2: Some(mut shard2),
+                    elem1,
+                    elem2,
+                    key1,
+                    key2,
+                } => {
+                    let (r1, r2) = value((elem1.as_ref().map(|_| ()), elem2.as_ref().map(|_| ())));
+                    // let (k1, v1) = elem1.unwrap_or_else(|| {
+                    //     let value = r1.expect("some value");
+                    //     let key = key1;
+                    //     let shard = &mut shard1;
+                    //     println!("{:p}", shard);
+                    //     println!("{:p}", &key);
+                    //     println!("{}", shard.hasher().hash_one(&key));
+                    //     insert2(key, shard, value)
+                    // });
+                    // let (k2, v2) = elem2.unwrap_or_else(|| {
+                    //     let value = r2.expect("some value");
+                    //     let key = key2;
+                    //     let shard = &mut shard2;
+                    //     insert2(key, shard, value)
+                    // });
+                    let k1 = key1.clone();
+                    let k2 = key2.clone();
+                    dbg!(&k1);
+                    dbg!(&k2);
+                    println!("{:p}", &k1);
+                    println!("{:p}", &k2);
+                    println!("{:p}", &r1);
+                    println!("{:p}", &r2);
+                    if elem1.is_none() {
+                        let value = r1.expect("some value");
+                        dbg!(&value);
+                        println!("{:p}", &value);
+                        let key = key1;
+                        let shard = &mut shard1;
+                        insert2_p1_shard(key, shard, value)
+                    }
+                    if elem2.is_none() {
+                        let value = r2.expect("some value");
+                        dbg!(&value);
+                        println!("{:p}", &value);
+                        let key = key2;
+                        let shard = &mut shard2;
+                        insert2_p1(key, shard, value)
+                    }
+                    let (k1, v1) = elem1.unwrap_or_else(|| {
+                        let shard = &mut shard1;
+                        dbg!(shard.hasher().hash_one(&k1));
+                        let shard: &mut RwLockWriteGuard<HashMap<K, SharedValue<V>>> =
+                            unsafe { std::mem::transmute(shard) };
+                        insert2_p2_shard(&k1, shard)
+                    });
+                    let (k2, v2) = elem2.unwrap_or_else(|| {
+                        let shard = &mut shard2;
+                        insert2_p2(&k2, shard)
+                    });
+                    println!("{:p}", &shard1);
+                    dbg!(shard1.len());
+                    println!("{:p}", &shard2);
+                    dbg!(shard2.len());
+                    dbg!(v1);
+                    dbg!(v2);
+                    RefMut {
+                        guard1: shard1,
+                        guard2: Some(shard2),
+                        k1,
+                        k2,
+                        v1,
+                        v2,
+                    }
+                }
+            }
+        }
+    }
+
+    fn insert2<'a, K: Eq + Hash, V, S: BuildHasher>(
+        key: K,
+        shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
+        value: V,
+    ) -> (*const K, *mut V) {
+        let c = unsafe { std::ptr::read(&key) };
+        shard.insert(key, value);
+        // let shard: &mut RwLockWriteGuard<HashMap<K, SharedValue<V>>> =
+        //     unsafe { std::mem::transmute(shard) };
+        {
+            // let shard: &'a mut RwLockWriteGuard<'a, HashMap<K, SharedValue<V>>> = shard;
+            unsafe {
+                use std::mem;
+                dbg!();
+                let (k, v) = shard.get_key_value(&c).unwrap();
+                dbg!();
+                let k = change_lifetime_const(k);
+                dbg!();
+                let v = &mut *shard_as_ptr2(v);
+                dbg!();
+                mem::forget(c);
+                dbg!();
+                (k, v)
+            }
+        }
+    }
+
+    fn insert2_p1<'a, K: Eq + Hash, V, S: BuildHasher>(
+        key: K,
+        shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
+        value: V,
+    ) {
+        println!("{:p}", &key);
+        println!("{}", shard.hasher().hash_one(&key));
+        println!("{:p}", &value);
+        shard.insert(key, value);
+    }
+
+    fn insert2_p1_shard<'a, K: Eq + Hash, V, S: BuildHasher>(
+        key: K,
+        shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
+        value: V,
+    ) {
+        println!("{:p}", &key);
+        println!("{}", shard.hasher().hash_one(&key));
+        println!("{:p}", &value);
+        // let shard: &mut RwLockWriteGuard<HashMap<K, SharedValue<V>>> =
+        //             unsafe { std::mem::transmute(shard) };
+        // let value: SharedValue<V> = SharedValue::new(value);
+        println!("{:p}", &key);
+        println!("{}", shard.hasher().hash_one(&key));
+        println!("{:p}", &value);
+        // todo!()
+        shard.insert(key, value);
+    }
+
+    fn insert2_p2<'a, K: Eq + Hash, V, S: BuildHasher>(
+        key: &K,
+        shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
+    ) -> (*const K, *mut V) {
+        unsafe {
+            use std::mem;
+            dbg!();
+            println!("{:p}", &key);
+            println!("{}", shard.hasher().hash_one(&key));
+            let (k, v) = shard.get_key_value(key).unwrap();
+            dbg!();
+            let k = change_lifetime_const(k);
+            dbg!();
+            let v = &mut *shard_as_ptr2(v);
+            dbg!();
+            (k, v)
+        }
+    }
+
+    fn insert2_p2_shard<'a, K: Eq + Hash, V, S: BuildHasher>(
+        key: &K,
+        shard: &mut RwLockWriteGuard<'a, HashMap<K, SharedValue<V>, S>>,
+    ) -> (*const K, *mut V) {
+        unsafe {
+            dbg!();
+            println!("{:p}", &key);
+            println!("{}", shard.hasher().hash_one(&key));
+            todo!();
+
+            let (k, v) = shard.get_key_value(key).unwrap();
+            dbg!();
+            let k = change_lifetime_const(k);
+            dbg!();
+            let v = &mut *shard_as_ptr(v);
+            dbg!();
+            (k, v)
+        }
+    }
+
+    fn insert<'a, K: Eq + Hash, V>(
+        key: K,
+        shard: &'a mut RwLockWriteGuard<'a, HashMap<K, SharedValue<V>>>,
+        value: SharedValue<V>,
+    ) -> (*const K, *mut V) {
+        unsafe {
+            use std::mem;
+            use std::ptr;
+            let c: K = ptr::read(&key);
+            dbg!();
+            println!("{:p}", &key);
+            println!("{}", shard.hasher().hash_one(&key));
+            println!("{:p}", &value);
+            {
+                // let shard: &mut RwLockWriteGuard<HashMap<K, V>> =
+                //     unsafe { std::mem::transmute(shard) };
+                // let value: V =
+                //     unsafe { std::mem::transmute(value) };
+                shard.insert(key, value);
+            }
+            dbg!();
+            let (k, v) = shard.get_key_value(&c).unwrap();
+            dbg!();
+            let k = change_lifetime_const(k);
+            dbg!();
+            let v = &mut *shard_as_ptr(v);
+            dbg!();
+            mem::forget(c);
+            dbg!();
+            (k, v)
+        }
+    }
+
+    /// # Safety
+    ///
+    /// Requires that you ensure the reference does not become invalid.
+    /// The object has to outlive the reference.
+    unsafe fn change_lifetime_const<'a, 'b, T>(x: &'a T) -> &'b T {
+        &*(x as *const T)
+    }
+
+    pub struct RefMut<'a, K, V, S = RandomState> {
+        guard1: RwLockWriteGuard<'a, HashMap<K, V, S>>,
+        guard2: Option<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
+        k1: *const K,
+        k2: *const K,
+        v1: *mut V,
+        v2: *mut V,
+    }
+
+    unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Send for RefMut<'a, K, V, S> {}
+    unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Sync for RefMut<'a, K, V, S> {}
+
+    impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMut<'a, K, V, S> {
+        pub fn value_mut(&mut self) -> (&mut V, &mut V) {
+            unsafe { (&mut *self.v1, &mut *self.v2) }
+        }
+    }
+}
+
+// WARN lazy subtrees are not complete
+fn lazy_subtree_mapping<'a, 'b>(
+    repositories: &'a multi_preprocessed::PreProcessedRepositories,
+    partial_comp_cache: &'a crate::PartialDecompCache,
+    src_tr: NodeIdentifier,
+    dst_tr: NodeIdentifier,
+) -> hyper_diff::matchers::Mapping<
+    dashmap::mapref::one::RefMut<
+        'a,
+        NodeIdentifier,
+        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
+            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
+            u32,
+        >,
+    >,
+    dashmap::mapref::one::RefMut<
+        'a,
+        NodeIdentifier,
+        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
+            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
+            u32,
+        >,
+    >,
+    mapping_store::MultiVecStore<u32>,
+> {
+    use hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder;
+    use hyper_diff::matchers::heuristic::gt::lazy2_greedy_subtree_matcher::LazyGreedySubtreeMatcher;
+    use hyper_diff::matchers::mapping_store::DefaultMultiMappingStore;
+    use hyper_diff::matchers::mapping_store::MappingStore;
+    use hyper_diff::matchers::mapping_store::VecStore;
+    use hyper_diff::matchers::Mapping;
+
+    let hyperast = &repositories.processor.main_stores;
+    let src = &src_tr;
+    let dst = &dst_tr;
+    let now = Instant::now();
+    assert_ne!(src, dst);
+    let (mut decompress_src, mut decompress_dst) = {
+        use hyper_ast::types::DecompressedSubtree;
+        let mut cached_decomp = |id: &NodeIdentifier| -> Option<
+            dashmap::mapref::one::RefMut<NodeIdentifier, LazyPostOrder<HashedNodeRef<'a>, u32>>,
+        > {
+            let decompress = partial_comp_cache
+                .try_entry(*id)?
+                .or_insert_with(|| unsafe {
+                    std::mem::transmute(LazyPostOrder::<_, u32>::decompress(
+                        hyperast.node_store(),
+                        id,
+                    ))
+                });
+            Some(unsafe { std::mem::transmute(decompress) })
+        };
+        loop {
+            match (cached_decomp(src), cached_decomp(dst)) {
+                (Some(decompress_src), Some(decompress_dst)) => {
+                    break (decompress_src, decompress_dst)
+                }
+                (None, None) => {
+                    dbg!();
+                }
+                _ => {
+                    dbg!(
+                        partial_comp_cache.hash_usize(src),
+                        partial_comp_cache.hash_usize(dst)
+                    );
+                    dbg!(
+                        partial_comp_cache.determine_shard(partial_comp_cache.hash_usize(src)),
+                        partial_comp_cache.determine_shard(partial_comp_cache.hash_usize(dst))
+                    );
+                }
+            }
+            sleep(Duration::from_secs(2));
+        }
+    };
+    hyperast
+        .node_store
+        .resolve(decompress_src.original(&decompress_src.root()));
+    hyperast
+        .node_store
+        .resolve(decompress_dst.original(&decompress_dst.root()));
+
+    let mappings = VecStore::default();
+    let mut mapper = Mapper {
+        hyperast,
+        mapping: Mapping {
+            src_arena: decompress_src.value_mut(),
+            dst_arena: decompress_dst.value_mut(),
+            mappings,
+        },
+    };
+    mapper.mapping.mappings.topit(
+        mapper.mapping.src_arena.len(),
+        mapper.mapping.dst_arena.len(),
+    );
+    dbg!();
+    let mm = LazyGreedySubtreeMatcher::<
+        'a,
+        SimpleStores<TStore>,
+        &mut LazyPostOrder<HashedNodeRef<'a>, u32>,
+        &mut LazyPostOrder<HashedNodeRef<'a>, u32>,
+        VecStore<_>,
+    >::compute_multi_mapping::<DefaultMultiMappingStore<_>>(&mut mapper);
+    dbg!();
+
+    hyper_diff::matchers::Mapping {
+        src_arena: decompress_src,
+        dst_arena: decompress_dst,
+        mappings: mm,
+    }
+}
+
+pub fn child_by_type<'store, HAST: HyperAST<'store, IdN = NodeIdentifier>>(
+    stores: &'store HAST,
+    d: NodeIdentifier,
+    t: &<HAST::TS as types::TypeStore<HAST::T>>::Ty,
+) -> Option<(NodeIdentifier, usize)> {
+    let n = stores.node_store().resolve(&d);
+    let s = n
+        .children()
+        .unwrap()
+        .iter_children()
+        .enumerate()
+        .find(|(_, x)| {
+            stores.resolve_type(*x).eq(t)
+        })
+        .map(|(i, x)| (*x, i));
+    s
+}

--- a/client/src/track/more.rs
+++ b/client/src/track/more.rs
@@ -1,0 +1,272 @@
+use super::*;
+
+
+// fn diff<'a>(
+//     repositories: &'a multi_preprocessed::PreProcessedRepositories,
+//     mappings: &'a mut crate::MappingCache,
+//     src_tr: NodeIdentifier,
+//     dst_tr: NodeIdentifier,
+// ) -> &'a hyper_diff::matchers::Mapping<
+//     hyper_diff::decompressed_tree_store::CompletePostOrder<
+//         hyper_ast::store::nodes::legion::HashedNodeRef<'a>,
+//         u32,
+//     >,
+//     hyper_diff::decompressed_tree_store::CompletePostOrder<
+//         hyper_ast::store::nodes::legion::HashedNodeRef<'a>,
+//         u32,
+//     >,
+//     hyper_diff::matchers::mapping_store::VecStore<u32>,
+// > {
+//     use hyper_diff::decompressed_tree_store::CompletePostOrder;
+//     let mapped = mappings.entry((src_tr, dst_tr)).or_insert_with(|| {
+//         hyper_diff::algorithms::gumtree_lazy::diff(
+//             &repositories.processor.main_stores,
+//             &src_tr,
+//             &dst_tr,
+//         )
+//         .mapper
+//         .persist()
+//     });
+//     unsafe { Mapper::<_,CompletePostOrder<_,_>,CompletePostOrder<_,_>,_>::unpersist(&repositories.processor.main_stores, &*mapped) }
+// }
+
+// WARN lazy subtrees are not complete
+fn lazy_mapping<'a>(
+    repositories: &'a multi_preprocessed::PreProcessedRepositories,
+    mappings: &'a crate::MappingCache,
+    src_tr: NodeIdentifier,
+    dst_tr: NodeIdentifier,
+) -> dashmap::mapref::one::RefMut<
+    'a,
+    (NodeIdentifier, NodeIdentifier),
+    hyper_diff::matchers::Mapping<
+        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
+            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
+            u32,
+        >,
+        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
+            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
+            u32,
+        >,
+        hyper_diff::matchers::mapping_store::VecStore<u32>,
+    >,
+> {
+    use hyper_ast::types::HyperAST;
+    use hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder;
+    use hyper_diff::matchers::heuristic::gt::{
+        lazy2_greedy_bottom_up_matcher::GreedyBottomUpMatcher,
+        lazy2_greedy_subtree_matcher::LazyGreedySubtreeMatcher,
+    };
+    use hyper_diff::matchers::mapping_store::DefaultMultiMappingStore;
+    use hyper_diff::matchers::mapping_store::MappingStore;
+    use hyper_diff::matchers::mapping_store::VecStore;
+    let mapped = mappings.entry((src_tr, dst_tr)).or_insert_with(|| {
+        let hyperast = &repositories.processor.main_stores;
+        let src = &src_tr;
+        let dst = &dst_tr;
+        let now = Instant::now();
+        let mapper: Mapper<_, LazyPostOrder<_, u32>, LazyPostOrder<_, u32>, VecStore<_>> =
+            hyperast.decompress_pair(src, dst).into();
+        let subtree_prepare_t = now.elapsed().as_secs_f64();
+        let now = Instant::now();
+        let mapper =
+            LazyGreedySubtreeMatcher::<_, _, _, _>::match_it::<DefaultMultiMappingStore<_>>(mapper);
+        let subtree_matcher_t = now.elapsed().as_secs_f64();
+        let subtree_mappings_s = mapper.mappings().len();
+        dbg!(&subtree_matcher_t, &subtree_mappings_s);
+        let bottomup_prepare_t = 0.;
+        let now = Instant::now();
+        let mapper = GreedyBottomUpMatcher::<_, _, _, _, VecStore<_>>::match_it(mapper);
+        dbg!(&now.elapsed().as_secs_f64());
+        let bottomup_matcher_t = now.elapsed().as_secs_f64();
+        let bottomup_mappings_s = mapper.mappings().len();
+        dbg!(&bottomup_matcher_t, &bottomup_mappings_s);
+        // let now = Instant::now();
+
+        // NOTE could also have completed trees
+        // let node_store = hyperast.node_store();
+        // let mapper = mapper.map(
+        //     |src_arena| CompletePostOrder::from(src_arena.complete(node_store)),
+        //     |dst_arena| {
+        //         let complete = CompletePostOrder::from(dst_arena.complete(node_store));
+        //         SimpleBfsMapper::from(node_store, complete)
+        //     },
+        // );
+
+        // NOTE we do not use edit scripts here
+        // let prepare_gen_t = now.elapsed().as_secs_f64();
+        // let now = Instant::now();
+        // let actions = ScriptGenerator::compute_actions(mapper.hyperast, &mapper.mapping).ok();
+        // let gen_t = now.elapsed().as_secs_f64();
+        // dbg!(gen_t);
+        // let mapper = mapper.map(|x| x, |dst_arena| dst_arena.back);
+        Mapper::<_, LazyPostOrder<_, _>, LazyPostOrder<_, _>, _>::persist(mapper)
+    });
+    pub unsafe fn unpersist<'a>(
+        _hyperast: &'a SimpleStores<TStore>,
+        p: dashmap::mapref::one::RefMut<
+            'a,
+            (NodeIdentifier, NodeIdentifier),
+            hyper_diff::matchers::Mapping<
+                LazyPostOrder<
+                    hyper_diff::decompressed_tree_store::PersistedNode<NodeIdentifier>,
+                    u32,
+                >,
+                LazyPostOrder<
+                    hyper_diff::decompressed_tree_store::PersistedNode<NodeIdentifier>,
+                    u32,
+                >,
+                VecStore<u32>,
+            >,
+        >,
+    ) -> dashmap::mapref::one::RefMut<
+        'a,
+        (NodeIdentifier, NodeIdentifier),
+        hyper_diff::matchers::Mapping<
+            LazyPostOrder<HashedNodeRef<'a, NodeIdentifier>, u32>,
+            LazyPostOrder<HashedNodeRef<'a, NodeIdentifier>, u32>,
+            VecStore<u32>,
+        >,
+    > {
+        unsafe { std::mem::transmute(p) }
+    }
+    unsafe { unpersist(&repositories.processor.main_stores, mapped) }
+}
+
+struct RRR<'a>(
+    dashmap::mapref::one::Ref<
+        'a,
+        (NodeIdentifier, NodeIdentifier),
+        (
+            crate::MappingStage,
+            hyper_diff::matchers::mapping_store::VecStore<u32>,
+        ),
+    >,
+);
+
+// WARN lazy subtrees are not complete
+fn lazy_subtree_mapping<'a, 'b>(
+    repositories: &'a multi_preprocessed::PreProcessedRepositories,
+    partial_comp_cache: &'a crate::PartialDecompCache,
+    src_tr: NodeIdentifier,
+    dst_tr: NodeIdentifier,
+) -> hyper_diff::matchers::Mapping<
+    dashmap::mapref::one::RefMut<
+        'a,
+        NodeIdentifier,
+        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
+            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
+            u32,
+        >,
+    >,
+    dashmap::mapref::one::RefMut<
+        'a,
+        NodeIdentifier,
+        hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
+            hyper_ast::store::nodes::legion::HashedNodeRef<'a, NodeIdentifier>,
+            u32,
+        >,
+    >,
+    mapping_store::MultiVecStore<u32>,
+> {
+    use hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder;
+    use hyper_diff::matchers::heuristic::gt::lazy2_greedy_subtree_matcher::LazyGreedySubtreeMatcher;
+    use hyper_diff::matchers::mapping_store::DefaultMultiMappingStore;
+    use hyper_diff::matchers::mapping_store::MappingStore;
+    use hyper_diff::matchers::mapping_store::VecStore;
+    use hyper_diff::matchers::Mapping;
+
+    let hyperast = &repositories.processor.main_stores;
+    let src = &src_tr;
+    let dst = &dst_tr;
+    let now = Instant::now();
+    assert_ne!(src, dst);
+    let (mut decompress_src, mut decompress_dst) = {
+        use hyper_ast::types::DecompressedSubtree;
+        let mut cached_decomp = |id: &NodeIdentifier| -> Option<
+            dashmap::mapref::one::RefMut<NodeIdentifier, LazyPostOrder<HashedNodeRef<'a>, u32>>,
+        > {
+            let decompress = partial_comp_cache
+                .try_entry(*id)?
+                .or_insert_with(|| unsafe {
+                    std::mem::transmute(LazyPostOrder::<_, u32>::decompress(
+                        hyperast.node_store(),
+                        id,
+                    ))
+                });
+            Some(unsafe { std::mem::transmute(decompress) })
+        };
+        loop {
+            match (cached_decomp(src), cached_decomp(dst)) {
+                (Some(decompress_src), Some(decompress_dst)) => {
+                    break (decompress_src, decompress_dst)
+                }
+                (None, None) => {
+                    dbg!();
+                }
+                _ => {
+                    dbg!(
+                        partial_comp_cache.hash_usize(src),
+                        partial_comp_cache.hash_usize(dst)
+                    );
+                    dbg!(
+                        partial_comp_cache.determine_shard(partial_comp_cache.hash_usize(src)),
+                        partial_comp_cache.determine_shard(partial_comp_cache.hash_usize(dst))
+                    );
+                }
+            }
+            sleep(Duration::from_secs(2));
+        }
+    };
+    hyperast
+        .node_store
+        .resolve(decompress_src.original(&decompress_src.root()));
+    hyperast
+        .node_store
+        .resolve(decompress_dst.original(&decompress_dst.root()));
+
+    let mappings = VecStore::default();
+    let mut mapper = Mapper {
+        hyperast,
+        mapping: Mapping {
+            src_arena: decompress_src.value_mut(),
+            dst_arena: decompress_dst.value_mut(),
+            mappings,
+        },
+    };
+    mapper.mapping.mappings.topit(
+        mapper.mapping.src_arena.len(),
+        mapper.mapping.dst_arena.len(),
+    );
+    dbg!();
+    let mm = LazyGreedySubtreeMatcher::<
+        'a,
+        SimpleStores<TStore>,
+        &mut LazyPostOrder<HashedNodeRef<'a>, u32>,
+        &mut LazyPostOrder<HashedNodeRef<'a>, u32>,
+        VecStore<_>,
+    >::compute_multi_mapping::<DefaultMultiMappingStore<_>>(&mut mapper);
+    dbg!();
+
+    hyper_diff::matchers::Mapping {
+        src_arena: decompress_src,
+        dst_arena: decompress_dst,
+        mappings: mm,
+    }
+}
+
+pub fn child_by_type<'store, HAST: HyperAST<'store, IdN = NodeIdentifier>>(
+    stores: &'store HAST,
+    d: NodeIdentifier,
+    t: &<HAST::TS as types::TypeStore<HAST::T>>::Ty,
+) -> Option<(NodeIdentifier, usize)> {
+    let n = stores.node_store().resolve(&d);
+    let s = n
+        .children()
+        .unwrap()
+        .iter_children()
+        .enumerate()
+        .find(|(_, x)| stores.resolve_type(*x).eq(t))
+        .map(|(i, x)| (*x, i));
+    s
+}

--- a/client/src/track/my_dash.rs
+++ b/client/src/track/my_dash.rs
@@ -1,0 +1,455 @@
+use std::{
+    cell::UnsafeCell,
+    collections::hash_map::RandomState,
+    fmt::Debug,
+    hash::{BuildHasher, Hash},
+};
+
+use dashmap::{DashMap, RwLockWriteGuard, SharedValue};
+use hashbrown::HashMap;
+
+// pub fn entries<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone>(
+//     map: DashMap<K, V, S>,
+//     key1: K,
+//     key2: K,
+// ) -> Entry<'a, K, V, S> {
+//     let hash = map.hash_usize(&key1);
+
+//     let idx = map.determine_shard(hash);
+
+//     let shard: RwLockWriteGuard<HashMap<K, SharedValue<V>, S>> = unsafe {
+//         debug_assert!(idx < map.shards().len());
+
+//         map.shards().get_unchecked(idx).write()
+//     };
+
+//     #[repr(transparent)]
+//     struct MySharedValue<T> {
+//         value: UnsafeCell<T>,
+//     }
+
+//     impl<T> MySharedValue<T> {
+//         /// Get a mutable raw pointer to the underlying value
+//         fn as_ptr(&self) -> *mut T {
+//             self.value.get()
+//         }
+//     }
+//     // SAFETY: Sharded and UnsafeCell are transparent wrappers of V
+//     let shard: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard) };
+//     if let Some((kptr, vptr)) = shard.get_key_value(&key1) {
+//         unsafe {
+//             let kptr: *const K = kptr;
+//             // SAFETY: same memory layout because transparent and same fields
+//             let vptr: &MySharedValue<V> = std::mem::transmute(&vptr);
+//             let vptr: *mut V = vptr.as_ptr();
+//             Entry::Occupied(OccupiedEntry::new(shard, key1, (kptr, vptr)))
+//         }
+//     } else {
+//         unsafe {
+//             // SAFETY: same memory layout because transparent and same fields
+//             let shard: RwLockWriteGuard<HashMap<K, V, S>> = std::mem::transmute(shard);
+//             Entry::Vacant(VacantEntry::new(shard, key1))
+//         }
+//     }
+pub fn entries<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone>(
+    map: &'a DashMap<K, V, S>,
+    key1: K,
+    key2: K,
+) -> Entry<'a, K, V, S> {
+    assert!(key1 != key2, "keys should be different");
+    let hash1 = map.hash_usize(&key1);
+    let idx1 = map.determine_shard(hash1);
+    let hash2 = map.hash_usize(&key2);
+    let idx2 = map.determine_shard(hash2);
+
+    if idx1 == idx2 {
+        let shard = unsafe {
+            debug_assert!(idx1 < map.shards().len());
+            debug_assert!(idx2 < map.shards().len());
+            map.shards().get_unchecked(idx1).write()
+        };
+        // SAFETY: Sharded and UnsafeCell are transparent wrappers of V
+        let shard: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard) };
+        let elem1 = shard
+            .get_key_value(&key1)
+            .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
+        let elem2 = shard
+            .get_key_value(&key2)
+            .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
+        Entry {
+            shard1: shard,
+            shard2: None,
+            key1,
+            key2,
+            elem1,
+            elem2,
+        }
+    } else {
+        let (shard1, shard2) = unsafe {
+            debug_assert!(idx1 < map.shards().len());
+            debug_assert!(idx2 < map.shards().len());
+            (
+                map.shards().get_unchecked(idx1).write(),
+                map.shards().get_unchecked(idx2).write(),
+            )
+        };
+        let shard1: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard1) };
+        let shard2: RwLockWriteGuard<HashMap<K, V, S>> = unsafe { std::mem::transmute(shard2) };
+        let elem1 = shard1
+            .get_key_value(&key1)
+            .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
+        let elem2 = shard2
+            .get_key_value(&key2)
+            .map(|(kptr, vptr)| unsafe { as_ptr(kptr, vptr) });
+        Entry {
+            shard1: shard1,
+            shard2: Some(shard2),
+            key1,
+            key2,
+            elem1,
+            elem2,
+        }
+    }
+}
+
+unsafe fn as_ptr<'a, K: 'a + Eq + Hash, V: 'a>(kptr1: &K, vptr1: &V) -> (*const K, *mut V) {
+    let kptr1: *const K = kptr1;
+    // SAFETY: same memory layout because transparent and same fields
+    let vptr1: &MySharedValue<V> = std::mem::transmute(&vptr1);
+    let vptr1: *mut V = vptr1.as_ptr();
+    (kptr1, vptr1)
+}
+
+pub(super) unsafe fn shard_as_ptr<'a, V: 'a>(vptr1: &SharedValue<V>) -> *mut V {
+    // SAFETY: same memory layout because transparent and same fields
+    let vptr1: &MySharedValue<V> = std::mem::transmute(&vptr1);
+    let vptr1: *mut V = vptr1.as_ptr();
+    vptr1
+}
+
+pub(super) unsafe fn shard_as_ptr2<'a, V: 'a>(vptr1: &V) -> *mut V {
+    // SAFETY: same memory layout because transparent and same fields
+    let vptr1: &MySharedValue<V> = std::mem::transmute(&vptr1);
+    let vptr1: *mut V = vptr1.as_ptr();
+    vptr1
+}
+
+#[repr(transparent)]
+struct MySharedValue<T> {
+    value: UnsafeCell<T>,
+}
+
+impl<T> MySharedValue<T> {
+    /// Get a mutable raw pointer to the underlying value
+    fn as_ptr(&self) -> *mut T {
+        self.value.get()
+    }
+}
+pub struct Entry<'a, K, V, S = RandomState> {
+    shard1: RwLockWriteGuard<'a, HashMap<K, V, S>>,
+    shard2: Option<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
+    elem1: Option<(*const K, *mut V)>,
+    elem2: Option<(*const K, *mut V)>,
+    key1: K,
+    key2: K,
+}
+unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Send for Entry<'a, K, V, S> {}
+unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Sync for Entry<'a, K, V, S> {}
+
+impl<'a, K: Clone + Eq + Hash + Debug, V: Debug, S: BuildHasher> Entry<'a, K, V, S> {
+    pub fn or_insert_with(
+        self,
+        value: impl FnOnce((Option<()>, Option<()>)) -> (Option<V>, Option<V>),
+    ) -> RefMut<'a, K, V, S> {
+        match self {
+            Entry {
+                shard1,
+                shard2,
+                elem1: Some((k1, v1)),
+                elem2: Some((k2, v2)),
+                ..
+            } => {
+                dbg!(v1);
+                dbg!(v2);
+                RefMut {
+                    guard1: shard1,
+                    guard2: shard2,
+                    k1,
+                    k2,
+                    v1,
+                    v2,
+                }
+            }
+            Entry {
+                mut shard1,
+                shard2: None,
+                elem1,
+                elem2,
+                key1,
+                key2,
+            } => {
+                let (r1, r2) = value((elem1.as_ref().map(|_| ()), elem2.as_ref().map(|_| ())));
+                let k1 = key1.clone();
+                let k2 = key2.clone();
+                if elem1.is_none() {
+                    let value = r1.expect("some value");
+                    let key = key1;
+                    let shard = &mut shard1;
+                    insert2_p1(key, shard, value)
+                }
+                if elem2.is_none() {
+                    let value = r2.expect("some value");
+                    let key = key2;
+                    let shard = &mut shard1;
+                    insert2_p1(key, shard, value)
+                }
+                let (k1, v1) = elem1.unwrap_or_else(|| {
+                    let shard = &mut shard1;
+                    insert2_p2(&k1, shard)
+                });
+                let (k2, v2) = elem2.unwrap_or_else(|| {
+                    let shard = &mut shard1;
+                    insert2_p2(&k2, shard)
+                });
+                dbg!(v1);
+                dbg!(v2);
+                RefMut {
+                    guard1: shard1,
+                    guard2: None,
+                    k1,
+                    k2,
+                    v1,
+                    v2,
+                }
+            }
+            Entry {
+                mut shard1,
+                shard2: Some(mut shard2),
+                elem1,
+                elem2,
+                key1,
+                key2,
+            } => {
+                let (r1, r2) = value((elem1.as_ref().map(|_| ()), elem2.as_ref().map(|_| ())));
+                // let (k1, v1) = elem1.unwrap_or_else(|| {
+                //     let value = r1.expect("some value");
+                //     let key = key1;
+                //     let shard = &mut shard1;
+                //     println!("{:p}", shard);
+                //     println!("{:p}", &key);
+                //     println!("{}", shard.hasher().hash_one(&key));
+                //     insert2(key, shard, value)
+                // });
+                // let (k2, v2) = elem2.unwrap_or_else(|| {
+                //     let value = r2.expect("some value");
+                //     let key = key2;
+                //     let shard = &mut shard2;
+                //     insert2(key, shard, value)
+                // });
+                let k1 = key1.clone();
+                let k2 = key2.clone();
+                dbg!(&k1);
+                dbg!(&k2);
+                println!("{:p}", &k1);
+                println!("{:p}", &k2);
+                println!("{:p}", &r1);
+                println!("{:p}", &r2);
+                if elem1.is_none() {
+                    let value = r1.expect("some value");
+                    dbg!(&value);
+                    println!("{:p}", &value);
+                    let key = key1;
+                    let shard = &mut shard1;
+                    insert2_p1_shard(key, shard, value)
+                }
+                if elem2.is_none() {
+                    let value = r2.expect("some value");
+                    dbg!(&value);
+                    println!("{:p}", &value);
+                    let key = key2;
+                    let shard = &mut shard2;
+                    insert2_p1(key, shard, value)
+                }
+                let (k1, v1) = elem1.unwrap_or_else(|| {
+                    let shard = &mut shard1;
+                    dbg!(shard.hasher().hash_one(&k1));
+                    let shard: &mut RwLockWriteGuard<HashMap<K, SharedValue<V>>> =
+                        unsafe { std::mem::transmute(shard) };
+                    insert2_p2_shard(&k1, shard)
+                });
+                let (k2, v2) = elem2.unwrap_or_else(|| {
+                    let shard = &mut shard2;
+                    insert2_p2(&k2, shard)
+                });
+                println!("{:p}", &shard1);
+                dbg!(shard1.len());
+                println!("{:p}", &shard2);
+                dbg!(shard2.len());
+                dbg!(v1);
+                dbg!(v2);
+                RefMut {
+                    guard1: shard1,
+                    guard2: Some(shard2),
+                    k1,
+                    k2,
+                    v1,
+                    v2,
+                }
+            }
+        }
+    }
+}
+
+fn insert2<'a, K: Eq + Hash, V, S: BuildHasher>(
+    key: K,
+    shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
+    value: V,
+) -> (*const K, *mut V) {
+    let c = unsafe { std::ptr::read(&key) };
+    shard.insert(key, value);
+    // let shard: &mut RwLockWriteGuard<HashMap<K, SharedValue<V>>> =
+    //     unsafe { std::mem::transmute(shard) };
+    {
+        // let shard: &'a mut RwLockWriteGuard<'a, HashMap<K, SharedValue<V>>> = shard;
+        unsafe {
+            use std::mem;
+            dbg!();
+            let (k, v) = shard.get_key_value(&c).unwrap();
+            dbg!();
+            let k = change_lifetime_const(k);
+            dbg!();
+            let v = &mut *shard_as_ptr2(v);
+            dbg!();
+            mem::forget(c);
+            dbg!();
+            (k, v)
+        }
+    }
+}
+
+fn insert2_p1<'a, K: Eq + Hash, V, S: BuildHasher>(
+    key: K,
+    shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
+    value: V,
+) {
+    println!("{:p}", &key);
+    println!("{}", shard.hasher().hash_one(&key));
+    println!("{:p}", &value);
+    shard.insert(key, value);
+}
+
+fn insert2_p1_shard<'a, K: Eq + Hash, V, S: BuildHasher>(
+    key: K,
+    shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
+    value: V,
+) {
+    println!("{:p}", &key);
+    println!("{}", shard.hasher().hash_one(&key));
+    println!("{:p}", &value);
+    // let shard: &mut RwLockWriteGuard<HashMap<K, SharedValue<V>>> =
+    //             unsafe { std::mem::transmute(shard) };
+    // let value: SharedValue<V> = SharedValue::new(value);
+    println!("{:p}", &key);
+    println!("{}", shard.hasher().hash_one(&key));
+    println!("{:p}", &value);
+    // todo!()
+    shard.insert(key, value);
+}
+
+fn insert2_p2<'a, K: Eq + Hash, V, S: BuildHasher>(
+    key: &K,
+    shard: &mut RwLockWriteGuard<'a, HashMap<K, V, S>>,
+) -> (*const K, *mut V) {
+    unsafe {
+        use std::mem;
+        dbg!();
+        println!("{:p}", &key);
+        println!("{}", shard.hasher().hash_one(&key));
+        let (k, v) = shard.get_key_value(key).unwrap();
+        dbg!();
+        let k = change_lifetime_const(k);
+        dbg!();
+        let v = &mut *shard_as_ptr2(v);
+        dbg!();
+        (k, v)
+    }
+}
+
+fn insert2_p2_shard<'a, K: Eq + Hash, V, S: BuildHasher>(
+    key: &K,
+    shard: &mut RwLockWriteGuard<'a, HashMap<K, SharedValue<V>, S>>,
+) -> (*const K, *mut V) {
+    unsafe {
+        dbg!();
+        println!("{:p}", &key);
+        println!("{}", shard.hasher().hash_one(&key));
+        todo!();
+
+        let (k, v) = shard.get_key_value(key).unwrap();
+        dbg!();
+        let k = change_lifetime_const(k);
+        dbg!();
+        let v = &mut *shard_as_ptr(v);
+        dbg!();
+        (k, v)
+    }
+}
+
+fn insert<'a, K: Eq + Hash, V>(
+    key: K,
+    shard: &'a mut RwLockWriteGuard<'a, HashMap<K, SharedValue<V>>>,
+    value: SharedValue<V>,
+) -> (*const K, *mut V) {
+    unsafe {
+        use std::mem;
+        use std::ptr;
+        let c: K = ptr::read(&key);
+        dbg!();
+        println!("{:p}", &key);
+        println!("{}", shard.hasher().hash_one(&key));
+        println!("{:p}", &value);
+        {
+            // let shard: &mut RwLockWriteGuard<HashMap<K, V>> =
+            //     unsafe { std::mem::transmute(shard) };
+            // let value: V =
+            //     unsafe { std::mem::transmute(value) };
+            shard.insert(key, value);
+        }
+        dbg!();
+        let (k, v) = shard.get_key_value(&c).unwrap();
+        dbg!();
+        let k = change_lifetime_const(k);
+        dbg!();
+        let v = &mut *shard_as_ptr(v);
+        dbg!();
+        mem::forget(c);
+        dbg!();
+        (k, v)
+    }
+}
+
+/// # Safety
+///
+/// Requires that you ensure the reference does not become invalid.
+/// The object has to outlive the reference.
+unsafe fn change_lifetime_const<'a, 'b, T>(x: &'a T) -> &'b T {
+    &*(x as *const T)
+}
+
+pub struct RefMut<'a, K, V, S = RandomState> {
+    guard1: RwLockWriteGuard<'a, HashMap<K, V, S>>,
+    guard2: Option<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
+    k1: *const K,
+    k2: *const K,
+    v1: *mut V,
+    v2: *mut V,
+}
+
+unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Send for RefMut<'a, K, V, S> {}
+unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Sync for RefMut<'a, K, V, S> {}
+
+impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMut<'a, K, V, S> {
+    pub fn value_mut(&mut self) -> (&mut V, &mut V) {
+        unsafe { (&mut *self.v1, &mut *self.v2) }
+    }
+}

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -8,23 +8,23 @@ use hyper_ast::{
 use hyper_diff::decompressed_tree_store::{lazy_post_order, PersistedNode};
 
 pub type LPO<T> = SharedValue<lazy_post_order::LazyPostOrder<T, u32>>;
+type IdN = NodeIdentifier;
 
-pub(crate) fn get_pair_simp<'a, 'store, HAST: HyperAST<'store, IdN = NodeIdentifier>>(
+/// CAUTION a cache should be used on a single HyperAST
+/// btw a given HyperAST can be used by multiple caches
+pub(crate) fn get_pair_simp<'a, 'store, HAST: HyperAST<'store, IdN = IdN>>(
     partial_comp_cache: &'a crate::PartialDecompCache,
     hyperast: &'store HAST,
-    src: &NodeIdentifier,
-    dst: &NodeIdentifier,
-) -> (
-    &'a mut LPO<HAST::T>,
-    &'a mut LPO<HAST::T>,
-)
+    src: &IdN,
+    dst: &IdN,
+) -> (&'a mut LPO<HAST::T>, &'a mut LPO<HAST::T>)
 where
     <HAST as HyperAST<'store>>::T: WithStats,
 {
     use hyper_ast::types::DecompressedSubtree;
     use lazy_post_order::LazyPostOrder;
 
-    let (mut shard1, mut shard2) = bi_sharding(partial_comp_cache, src, dst);
+    let (shard1, shard2) = bi_sharding(partial_comp_cache, src, dst);
 
     let (v1, v2) = if shard2.is_none() {
         let shard1 = shard1.get_mut();
@@ -33,7 +33,7 @@ where
                 src.clone(),
                 SharedValue::new({
                     let src = LazyPostOrder::<_, u32>::decompress(hyperast.node_store(), src);
-                    let src: LazyPostOrder<PersistedNode<NodeIdentifier>, u32> =
+                    let src: LazyPostOrder<PersistedNode<IdN>, u32> =
                         unsafe { std::mem::transmute(src) };
                     src
                 }),
@@ -44,7 +44,7 @@ where
                 dst.clone(),
                 SharedValue::new({
                     let dst = LazyPostOrder::<_, u32>::decompress(hyperast.node_store(), dst);
-                    let dst: LazyPostOrder<PersistedNode<NodeIdentifier>, u32> =
+                    let dst: LazyPostOrder<PersistedNode<IdN>, u32> =
                         unsafe { std::mem::transmute(dst) };
                     dst
                 }),
@@ -55,21 +55,19 @@ where
     } else {
         let v1 = shard1.get_mut().entry(*src).or_insert_with(|| {
             let src = LazyPostOrder::<_, u32>::decompress(hyperast.node_store(), src);
-            let src: LazyPostOrder<PersistedNode<NodeIdentifier>, u32> =
-                unsafe { std::mem::transmute(src) };
+            let src: LazyPostOrder<PersistedNode<IdN>, u32> = unsafe { std::mem::transmute(src) };
             SharedValue::new(src)
         });
         let v2 = shard2.unwrap().get_mut().entry(*dst).or_insert_with(|| {
             let dst = LazyPostOrder::<_, u32>::decompress(hyperast.node_store(), dst);
-            let dst: LazyPostOrder<PersistedNode<NodeIdentifier>, u32> =
-                unsafe { std::mem::transmute(dst) };
+            let dst: LazyPostOrder<PersistedNode<IdN>, u32> = unsafe { std::mem::transmute(dst) };
             SharedValue::new(dst)
         });
         (v1, v2)
     };
 
     // SAFETY: should be the same hyperast TODO check if it is the case, store identifier along map ?
-    let mut res: (
+    let res: (
         &mut SharedValue<LazyPostOrder<<HAST as HyperAST<'store>>::T, u32>>,
         &mut SharedValue<LazyPostOrder<<HAST as HyperAST<'store>>::T, u32>>,
     ) = unsafe { std::mem::transmute((v1, v2)) };
@@ -78,15 +76,15 @@ where
 
 fn bi_sharding<'a>(
     partial_comp_cache: &'a crate::PartialDecompCache,
-    src: &NodeIdentifier,
-    dst: &NodeIdentifier,
+    src: &IdN,
+    dst: &IdN,
 ) -> (
     &'a mut RwLock<
         HashMap<
-            NodeIdentifier,
+            IdN,
             SharedValue<
                 hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
-                    PersistedNode<NodeIdentifier>,
+                    PersistedNode<IdN>,
                     u32,
                 >,
             >,
@@ -95,10 +93,10 @@ fn bi_sharding<'a>(
     Option<
         &'a mut RwLock<
             HashMap<
-                NodeIdentifier,
+                IdN,
                 SharedValue<
                     hyper_diff::decompressed_tree_store::lazy_post_order::LazyPostOrder<
-                        PersistedNode<NodeIdentifier>,
+                        PersistedNode<IdN>,
                         u32,
                     >,
                 >,
@@ -114,21 +112,19 @@ fn bi_sharding<'a>(
     let shards: &[_] = partial_comp_cache.shards();
     let shards = shards as *const [_];
     let shards = shards
-        as *mut [RwLock<
-            HashMap<NodeIdentifier, SharedValue<LazyPostOrder<PersistedNode<NodeIdentifier>, u32>>>,
-        >];
-    let mut shards = unsafe { shards.as_mut().unwrap() };
+        as *mut [RwLock<HashMap<IdN, SharedValue<LazyPostOrder<PersistedNode<IdN>, u32>>>>];
+    let shards = unsafe { shards.as_mut().unwrap() };
     // dbg!(index1, index2, shards.len());
     // let mut shards:&mut [_] = unsafe { std::mem::transmute(shards) };
 
-    // let mut shard1: &mut RwLock<HashMap<NodeIdentifier, SharedValue<LazyPostOrder<PersistedNode<NodeIdentifier>, u32>>>> = &mut shards[index1];
+    // let mut shard1: &mut RwLock<HashMap<IdN, SharedValue<LazyPostOrder<PersistedNode<IdN>, u32>>>> = &mut shards[index1];
     let (shard1, shard2) = if index1 == index2 {
         (&mut shards[index1], None)
     } else if index1 < index2 {
-        let (mut shards1, mut shards2) = shards.split_at_mut(index2);
+        let (shards1, shards2) = shards.split_at_mut(index2);
         (&mut shards1[index1], Some(&mut shards2[0]))
     } else {
-        let (mut shards2, mut shards1) = shards.split_at_mut(index1);
+        let (shards2, shards1) = shards.split_at_mut(index1);
         (&mut shards1[0], Some(&mut shards2[index2]))
     };
     (shard1, shard2)

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -7,17 +7,16 @@ use hyper_ast::{
 };
 use hyper_diff::decompressed_tree_store::{lazy_post_order, PersistedNode};
 
+pub type LPO<T> = SharedValue<lazy_post_order::LazyPostOrder<T, u32>>;
+
 pub(crate) fn get_pair_simp<'a, 'store, HAST: HyperAST<'store, IdN = NodeIdentifier>>(
     partial_comp_cache: &'a crate::PartialDecompCache,
     hyperast: &'store HAST,
     src: &NodeIdentifier,
     dst: &NodeIdentifier,
 ) -> (
-    &'a mut SharedValue<
-        // lazy_post_order::LazyPostOrder<hyper_ast::store::nodes::legion::HashedNodeRef<'a>, u32>,
-        lazy_post_order::LazyPostOrder<<HAST as HyperAST<'store>>::T, u32>,
-    >,
-    &'a mut SharedValue<lazy_post_order::LazyPostOrder<<HAST as HyperAST<'store>>::T, u32>>,
+    &'a mut LPO<HAST::T>,
+    &'a mut LPO<HAST::T>,
 )
 where
     <HAST as HyperAST<'store>>::T: WithStats,
@@ -119,7 +118,7 @@ fn bi_sharding<'a>(
             HashMap<NodeIdentifier, SharedValue<LazyPostOrder<PersistedNode<NodeIdentifier>, u32>>>,
         >];
     let mut shards = unsafe { shards.as_mut().unwrap() };
-    dbg!(index1, index2, shards.len());
+    // dbg!(index1, index2, shards.len());
     // let mut shards:&mut [_] = unsafe { std::mem::transmute(shards) };
 
     // let mut shard1: &mut RwLock<HashMap<NodeIdentifier, SharedValue<LazyPostOrder<PersistedNode<NodeIdentifier>, u32>>>> = &mut shards[index1];

--- a/cvs/git/Cargo.toml
+++ b/cvs/git/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-git2 = { version = "0.16.1", features = ["vendored-libgit2", "vendored-openssl"] }
+git2 = { version = "0.18.2", features = ["vendored-libgit2", "vendored-openssl"] }
 tree-sitter = "0.20.10"
 hyper_ast_gen_ts_cpp = { path = "../../gen/tree-sitter/cpp", optional = true }
 hyper_ast_gen_ts_java = { path = "../../gen/tree-sitter/java", optional = true }

--- a/cvs/git/src/git.rs
+++ b/cvs/git/src/git.rs
@@ -9,7 +9,22 @@ use hyper_ast::position::Position;
 
 use crate::processing::ObjectName;
 
-pub fn all_commits_between<'a>(
+/// Initialize a [git2::revwalk::Revwalk] to explore commits between before and after.
+/// 
+/// # Arguments
+///
+/// * `repository` - The repository where the walk is done
+/// * `before` - The the parent commit
+/// * `after` - The the child commit
+/// 
+/// # Property
+/// 
+/// if `after` is not a descendant of before then only walk `before`
+///
+/// # Errors
+/// 
+/// This function just lets errors from [git2] bubble up.
+pub(crate) fn all_commits_between<'a>(
     repository: &'a Repository,
     before: &str,
     after: &str,
@@ -17,10 +32,7 @@ pub fn all_commits_between<'a>(
     use git2::*;
     let mut rw = repository.revwalk()?;
     if !before.is_empty() {
-        // rw.hide_ref(before)?;
-        // log::debug!("{}", before);
         let c = retrieve_commit(repository, before)?;
-        // log::debug!("{:?}", c);
         for c in c.parents() {
             rw.hide(c.id())?;
         }

--- a/gen/tree-sitter/query/src/iter.rs
+++ b/gen/tree-sitter/query/src/iter.rs
@@ -1,0 +1,168 @@
+use std::fmt::{self, Debug};
+
+use hyper_ast::types::TypedHyperAST;
+use hyper_ast::{
+    position::{TreePath, TreePathMut},
+    store::nodes::legion::NodeIdentifier,
+    types::{
+        HyperAST, IterableChildren, NodeId, Tree, TypedNodeStore, WithChildren,
+    },
+};
+use num::ToPrimitive;
+
+use crate::types::TIdN;
+
+pub struct IterAll<'a, T, HAST> {
+    stores: &'a HAST,
+    path: T,
+    stack: Vec<(Id<NodeIdentifier>, u16, Option<Vec<NodeIdentifier>>)>,
+}
+
+enum Id<IdN> {
+    Query(TIdN<IdN>),
+    Other(IdN),
+}
+
+impl<IdN: Clone + Eq + NodeId> Id<IdN> {
+    fn id(&self) -> &IdN {
+        match self {
+            Id::Query(node) => node.as_id(),
+            Id::Other(node) => node,
+        }
+    }
+}
+
+impl<'a, T: TreePath<NodeIdentifier, u16>, HAST> Debug for IterAll<'a, T, HAST> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IterAllNodes")
+            // .field("parents", &self.parents())
+            .finish()
+    }
+}
+
+impl<'a, T: TreePath<NodeIdentifier, u16>, HAST: HyperAST<'a, IdN = NodeIdentifier>>
+    IterAll<'a, T, HAST>
+where
+    HAST::NS: TypedNodeStore<TIdN<HAST::IdN>>,
+{
+    pub fn new(stores: &'a HAST, path: T, root: NodeIdentifier) -> Self {
+        let root = if let Some(tid) = TypedNodeStore::try_typed(stores.node_store(), &root) {
+            Id::Query(tid)
+        } else {
+            Id::Other(root)
+        };
+        let stack = vec![(root, 0, None)];
+        Self {
+            stores,
+            path,
+            stack,
+        }
+    }
+}
+
+impl<
+        'a,
+        T: TreePathMut<NodeIdentifier, u16> + Clone + Debug,
+        HAST: TypedHyperAST<'a, TIdN<NodeIdentifier>, IdN = NodeIdentifier, Idx = u16>,
+    > Iterator for IterAll<'a, T, HAST>
+where
+    // HAST::NS: TypedNodeStore<TIdN<NodeIdentifier>>,
+    // HAST::TS: TypeStore<HAST::T, Ty = Type>,
+    // HAST::TT: TypedTree<Type = Type>,
+    // <HAST::T as Typed>::Type: Copy + Send + Sync,
+    // for<'b> <HAST::NS as TypedNodeStore<TIdN<HAST::IdN>>>::R<'b>:
+    //     TypedTree<Type = Type, TreeId = HAST::IdN, Label = HAST::Label, ChildIdx = u16>,
+    // <HAST::NS as NodeStore<HAST::IdN>>::R<'a>:
+    //     TypedTree<Type = AnyType, TreeId = HAST::IdN, Label = HAST::Label, ChildIdx = u16>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (node, offset, children) = self.stack.pop()?;
+            if let Some(children) = children {
+                if offset.to_usize().unwrap() < children.len() {
+                    let child = children[offset.to_usize().unwrap()];
+                    self.path.check(self.stores).unwrap();
+                    {
+                        let b = hyper_ast::types::NodeStore::resolve(
+                            self.stores.node_store(),
+                            node.id(),
+                        );
+                        if b.has_children() {
+                            assert!(offset < b.child_count());
+                            let cs = b.children();
+                            assert_eq!(child, cs.unwrap()[num::cast(offset).unwrap()]);
+                        } else {
+                            panic!()
+                        }
+                    }
+                    if offset == 0 {
+                        match self.path.node() {
+                            Some(x) => assert_eq!(x, node.id()),
+                            None => {}
+                        }
+                        self.path.goto(child, offset);
+                        self.path.check(self.stores).unwrap();
+                    } else {
+                        match self.path.node() {
+                            Some(x) => assert_eq!(*x, children[offset.to_usize().unwrap() - 1]),
+                            None => {}
+                        }
+                        self.path.inc(child);
+                        assert_eq!(*self.path.offset().unwrap(), offset + 1);
+                        self.path.check(self.stores).expect(&format!(
+                            "{:?} {} {:?} {:?} {:?}",
+                            node.id(),
+                            offset,
+                            child,
+                            children,
+                            self.path
+                        ));
+                    }
+                    self.stack.push((node, offset + 1, Some(children)));
+                    let child = if let Some(tid) =
+                        self.stores.typed_node_store().try_typed(&child)
+                    {
+                        Id::Query(tid)
+                    } else {
+                        Id::Other(child)
+                    };
+                    self.stack.push((child, 0, None));
+                    continue;
+                } else {
+                    self.path.check(self.stores).unwrap();
+                    self.path.pop().expect("should not go higher than root");
+                    self.path.check(self.stores).unwrap();
+                    continue;
+                }
+            } else {
+                let b = match &node {
+                    Id::Query(node) => self.stores.typed_node_store().resolve(node),
+                    Id::Other(node) => {
+                        let b =
+                            hyper_ast::types::NodeStore::resolve(self.stores.node_store(), node);
+                        if b.has_children() {
+                            let children = b.children();
+                            let children = children.unwrap();
+                            self.stack.push((
+                                Id::Other(*node),
+                                0,
+                                Some(children.iter_children().cloned().collect()),
+                            ));
+                        }
+                        continue;
+                    }
+                };
+
+                if b.has_children() {
+                    let children = b.children();
+                    let children = children.unwrap();
+                    self.stack
+                        .push((node, 0, Some(children.iter_children().cloned().collect())));
+                }
+                return Some(self.path.clone());
+            }
+        }
+    }
+}

--- a/gen/tree-sitter/query/src/lib.rs
+++ b/gen/tree-sitter/query/src/lib.rs
@@ -50,3 +50,6 @@ mod tnode {
 pub use tnode::TNode;
 
 pub mod search;
+
+#[cfg(feature = "legion")]
+pub mod iter;

--- a/gen/tree-sitter/query/src/lib.rs
+++ b/gen/tree-sitter/query/src/lib.rs
@@ -49,4 +49,4 @@ mod tnode {
 #[cfg(feature = "legion")]
 pub use tnode::TNode;
 
-mod search;
+pub mod search;

--- a/gen/tree-sitter/query/src/search.rs
+++ b/gen/tree-sitter/query/src/search.rs
@@ -25,7 +25,7 @@ pub(crate) struct QuickTrigger<T> {
     pub(crate) root_types: Arc<[T]>,
 }
 
-pub(crate) struct PreparedMatcher<'a, HAST, Ty> {
+pub struct PreparedMatcher<'a, HAST, Ty> {
     pub(crate) query_store: &'a HAST,
     pub(crate) quick_trigger: QuickTrigger<Ty>,
     pub(crate) patterns: Arc<[Pattern<Ty>]>,
@@ -49,9 +49,7 @@ impl<'a, 'b, Ty> PatternMatcher<'a, 'b, Ty> {
             + 'static,
         Ty: std::fmt::Debug + Eq + Copy,
     {
-        let n = code_store
-            .typed_node_store()
-            .resolve(&id);
+        let n = code_store.typed_node_store().resolve(&id);
         let t = n.get_type();
         dbg!(t);
         true
@@ -62,7 +60,11 @@ impl<'a, Ty: for<'b> TryFrom<&'b str>> PreparedMatcher<'a, SimpleStores<TStore>,
 where
     for<'b> <Ty as TryFrom<&'b str>>::Error: std::fmt::Debug,
 {
-    pub(crate) fn is_matching<'store, HAST, TIdN>(&self, code_store: &'store HAST, id: HAST::IdN) -> bool
+    pub fn is_matching<'store, HAST, TIdN>(
+        &self,
+        code_store: &'store HAST,
+        id: HAST::IdN,
+    ) -> bool
     where
         HAST: TypedHyperAST<'store, TIdN>,
         TIdN: hyper_ast::types::NodeId<IdN = HAST::IdN>
@@ -74,33 +76,60 @@ where
             return false;
         };
         let t = n.get_type();
-        dbg!(t);
         for i in 0..self.quick_trigger.root_types.len() {
             let tt = self.quick_trigger.root_types[i];
             let pat = &self.patterns[i];
             if t == tt {
-                dbg!(tt);
-                let b: bool = pat.is_matching(code_store, id.clone());
-                dbg!(tt, b);
+                let res: MatchingRes = pat.is_matching(code_store, id.clone());
+                if res.matched {
+                    return true;
+                }
             }
         }
         false
+    }
+    pub fn is_matching_and_capture<'store, HAST, TIdN>(
+        &self,
+        code_store: &'store HAST,
+        id: HAST::IdN,
+    ) -> Option<std::collections::HashMap<String, CaptureRes>>
+    where
+        HAST: TypedHyperAST<'store, TIdN>,
+        TIdN: hyper_ast::types::NodeId<IdN = HAST::IdN>
+            + hyper_ast::types::TypedNodeId<Ty = Ty>
+            + 'static,
+        Ty: std::fmt::Debug + Eq + Copy,
+    {
+        let Some((n, _)) = code_store.typed_node_store().try_resolve(&id) else {
+            return None;
+        };
+        let t = n.get_type();
+        for i in 0..self.quick_trigger.root_types.len() {
+            let tt = self.quick_trigger.root_types[i];
+            let pat = &self.patterns[i];
+            if t == tt {
+                let res: MatchingRes = pat.is_matching(code_store, id.clone());
+                if res.matched {
+                    return Some(res.captures);
+                }
+            }
+        }
+        None
     }
 }
 
 impl<'a, Ty> PreparedMatcher<'a, SimpleStores<TStore>, Ty>
 where
-    Ty: for<'b> TryFrom<&'b str>,
+    Ty: for<'b> TryFrom<&'b str> + std::fmt::Debug,
     for<'b> <Ty as TryFrom<&'b str>>::Error: std::fmt::Debug,
 {
-    pub(crate) fn new(
+    pub fn new(
         query_store: &'a SimpleStores<crate::types::TStore>,
         query: NodeIdentifier,
     ) -> Self {
         use crate::types::TIdN;
         use crate::types::Type;
-        use hyper_ast::store::nodes::legion::NodeIdentifier;
-        use hyper_ast::types::{LabelStore, NodeStore};
+        use hyper_ast::types::LabelStore;
         let mut root_types = vec![];
         let mut patterns = vec![];
         let n = query_store
@@ -109,7 +138,6 @@ where
             .unwrap()
             .0;
         let t = n.get_type();
-        dbg!(t);
         assert_eq!(t, Type::Program);
         for rule_id in n.children().unwrap().iter_children() {
             let rule = query_store
@@ -118,7 +146,6 @@ where
                 .unwrap()
                 .0;
             let t = rule.get_type();
-            dbg!(t);
             if t == Type::NamedNode {
                 let ty = rule.child(&1).unwrap();
                 let ty = query_store
@@ -126,18 +153,29 @@ where
                     .try_resolve_typed::<TIdN<NodeIdentifier>>(&ty)
                     .unwrap()
                     .0;
-                let t = ty.get_type();
-                dbg!(t);
+                assert_eq!(ty.get_type(), Type::Identifier);
                 let l = ty.try_get_label();
-                dbg!(l);
                 let l = query_store.label_store.resolve(&l.unwrap());
-                let l = Ty::try_from(l).unwrap();
+                let l = Ty::try_from(l).expect("the node type does not exist");
                 root_types.push(l);
-                patterns.push(Self::process_named_node(query_store, *rule_id).into())
+                patterns.push(Self::process_named_node(query_store, *rule_id).into());
             } else if t == Type::AnonymousNode {
                 todo!()
+            } else if t == Type::Spaces {
+            } else if t == Type::Predicate {
+                let prev = patterns
+                    .pop()
+                    .expect("a predicate should be preceded by a pattern");
+
+                let predicate = Self::preprocess_predicate(query_store, *rule_id);
+
+                let predicated = Pattern::Predicated {
+                    predicate,
+                    pat: Arc::new(prev),
+                };
+                patterns.push(predicated);
             } else {
-                todo!()
+                todo!("{}", t)
             }
         }
 
@@ -155,8 +193,7 @@ where
     ) -> Pattern<Ty> {
         use crate::types::TIdN;
         use crate::types::Type;
-        use hyper_ast::store::nodes::legion::NodeIdentifier;
-        use hyper_ast::types::{LabelStore, NodeStore};
+        use hyper_ast::types::LabelStore;
         let mut patterns = vec![];
         let n = query_store
             .node_store
@@ -165,7 +202,7 @@ where
             .0;
         let t = n.get_type();
         assert_eq!(t, Type::NamedNode);
-        let mut cs = n.children().unwrap().iter_children();
+        let mut cs = n.children().unwrap().iter_children().peekable();
         cs.next().unwrap();
         let ty = cs.next().unwrap();
         let ty = query_store
@@ -173,43 +210,115 @@ where
             .try_resolve_typed::<TIdN<NodeIdentifier>>(&ty)
             .unwrap()
             .0;
-        let t = ty.get_type();
-        dbg!(t);
+        assert_eq!(ty.get_type(), Type::Identifier);
         let l = ty.try_get_label();
-        dbg!(l);
         let l = query_store.label_store.resolve(&l.unwrap());
-        let l = Ty::try_from(l).unwrap();
-        for rule_id in cs {
+        let l = Ty::try_from(l).expect("the node type does not exist");
+        loop {
+            let Some(rule_id) = cs.peek() else { break };
             let rule = query_store
                 .node_store
-                .try_resolve_typed::<TIdN<NodeIdentifier>>(&rule_id)
+                .try_resolve_typed::<TIdN<NodeIdentifier>>(rule_id)
                 .unwrap()
                 .0;
             let t = rule.get_type();
-            dbg!(t);
             if t == Type::NamedNode {
-                patterns.push(Self::process_named_node(query_store, *rule_id).into())
+                patterns.push(Self::process_named_node(query_store, **rule_id).into())
             } else if t == Type::Spaces {
             } else if t == Type::RParen {
             } else if t == Type::AnonymousNode {
-                patterns.push(Self::process_anonymous_node(query_store, *rule_id).into())
+                patterns.push(Self::process_anonymous_node(query_store, **rule_id).into())
+            } else if t == Type::Capture {
+                break;
+            } else if t == Type::Predicate {
+                let prev = patterns.pop().expect("predicate must be preceded by node");
+                let predicate = Self::preprocess_predicate(query_store, **rule_id);
+                patterns.push(Pattern::Predicated {
+                    predicate,
+                    pat: Arc::new(prev),
+                });
             } else {
-                todo!()
+                todo!("{}", t)
             }
+            cs.next();
         }
-
-        Pattern::NamedNode {
+        let mut res = Pattern::NamedNode {
             ty: l,
             children: patterns.into(),
+        };
+        loop {
+            let Some(rule_id) = cs.peek() else {
+                return res;
+            };
+            let n = query_store
+                .node_store
+                .try_resolve_typed::<TIdN<NodeIdentifier>>(rule_id)
+                .unwrap()
+                .0;
+            let t = n.get_type();
+            if t == Type::Capture {
+                let mut cs = n.children().unwrap().iter_children();
+                let n = query_store
+                    .node_store
+                    .try_resolve_typed::<TIdN<NodeIdentifier>>(cs.next().unwrap())
+                    .unwrap()
+                    .0;
+                let t = n.get_type();
+                assert_eq!(t, Type::At);
+                let name = cs.next().unwrap();
+                let ty = query_store
+                    .node_store
+                    .try_resolve_typed::<TIdN<NodeIdentifier>>(name)
+                    .unwrap()
+                    .0;
+                assert_eq!(ty.get_type(), Type::Identifier);
+                let name = ty.try_get_label().unwrap();
+                let name = query_store.label_store.resolve(&name);
+                let name = name.to_string();
+                match &res {
+                    Pattern::NamedNode { .. } | Pattern::Capture { .. } => (),
+                    Pattern::Predicated { .. } => panic!(),
+                    Pattern::AnonymousNode { .. } => todo!("not sure if it works properly"),
+                    p => todo!("{:?} still not implemented to be captured", p), // TODO quantificators will need more works
+                }
+                res = Pattern::Capture {
+                    name,
+                    pat: Arc::new(res),
+                };
+            } else if t == Type::Quantifier {
+                break;
+            } else {
+                todo!("{}", t)
+            }
+            cs.next().unwrap();
+        }
+        loop {
+            let Some(rule_id) = cs.next() else {
+                break res;
+            };
+            let n = query_store
+                .node_store
+                .try_resolve_typed::<TIdN<NodeIdentifier>>(rule_id)
+                .unwrap()
+                .0;
+            let t = n.get_type();
+            if t == Type::Capture {
+                panic!("captures after predicated are not allowed");
+            } else if t == Type::Quantifier {
+                todo!()
+            } else {
+                todo!("{}", t)
+            }
         }
     }
+
     pub(crate) fn process_anonymous_node(
         query_store: &SimpleStores<TStore>,
         rule: NodeIdentifier,
     ) -> Pattern<Ty> {
         use crate::types::TIdN;
         use crate::types::Type;
-        use hyper_ast::types::{LabelStore, NodeStore};
+        use hyper_ast::types::LabelStore;
         let n = query_store
             .node_store()
             .try_resolve_typed::<TIdN<NodeIdentifier>>(&rule)
@@ -226,9 +335,7 @@ where
         //     .unwrap()
         //     .0;
         // let t = ty.get_type();
-        // dbg!(t);
         let l = n.try_get_label();
-        dbg!(l);
         let l = query_store.label_store().resolve(&l.unwrap());
         let l = &l[1..l.len() - 1];
         let l = Ty::try_from(l).unwrap();
@@ -249,15 +356,209 @@ where
         // }
         Pattern::AnonymousNode(l)
     }
+
+    pub(crate) fn preprocess_predicate(
+        query_store: &SimpleStores<TStore>,
+        rule: NodeIdentifier,
+    ) -> Predicate {
+        use crate::types::TIdN;
+        use crate::types::Type;
+        use hyper_ast::types::LabelStore;
+        let n = query_store
+            .node_store()
+            .try_resolve_typed::<TIdN<NodeIdentifier>>(&rule)
+            .unwrap()
+            .0;
+        let t = n.get_type();
+        assert_eq!(t, Type::Predicate);
+        let mut cs = n.children().unwrap().iter_children();
+        cs.next().unwrap();
+        let sharp = cs.next().unwrap();
+        let sharp = query_store
+            .node_store
+            .try_resolve_typed::<TIdN<NodeIdentifier>>(&sharp)
+            .unwrap()
+            .0;
+        let t = sharp.get_type();
+        assert_eq!(t, Type::TS3);
+
+        let pred = cs.next().unwrap();
+        let pred = query_store
+            .node_store
+            .try_resolve_typed::<TIdN<NodeIdentifier>>(&pred)
+            .unwrap()
+            .0;
+        let t = pred.get_type();
+        assert_eq!(t, Type::Identifier);
+
+        let l = pred.try_get_label();
+        let l = query_store.label_store().resolve(&l.unwrap());
+        match l {
+            "eq" => {
+                let pred = cs.next().unwrap();
+                let pred = query_store
+                    .node_store
+                    .try_resolve_typed::<TIdN<NodeIdentifier>>(&pred)
+                    .unwrap()
+                    .0;
+                let t = pred.get_type();
+                assert_eq!(t, Type::PredicateType);
+                let l = pred.try_get_label();
+                let l = query_store.label_store().resolve(&l.unwrap());
+                assert_eq!(l, "?");
+                for rule_id in cs {
+                    let rule = query_store
+                        .node_store
+                        .try_resolve_typed::<TIdN<NodeIdentifier>>(&rule_id)
+                        .unwrap()
+                        .0;
+                    let t = rule.get_type();
+                    if t == Type::Parameters {
+                        let mut cs = rule.children().unwrap().iter_children();
+                        let left = cs.next().unwrap();
+                        let left = query_store
+                            .node_store
+                            .try_resolve_typed::<TIdN<NodeIdentifier>>(left)
+                            .unwrap()
+                            .0;
+                        let left = match left.get_type() {
+                            Type::Capture => preprocess_capture_pred_arg(left, query_store),
+                            t => todo!("{}", t),
+                        };
+                        {
+                            let center = cs.next().unwrap();
+                            let center = query_store
+                                .node_store
+                                .try_resolve_typed::<TIdN<NodeIdentifier>>(center)
+                                .unwrap()
+                                .0;
+                            let t = center.get_type();
+                            assert_eq!(t, Type::Spaces);
+                        }
+                        let right = cs.next().unwrap();
+                        let right = query_store
+                            .node_store
+                            .try_resolve_typed::<TIdN<NodeIdentifier>>(right)
+                            .unwrap()
+                            .0;
+                        return match right.get_type() {
+                            Type::Capture => {
+                                let right = preprocess_capture_pred_arg(right, query_store);
+                                Predicate::Eq { left, right }
+                            }
+                            Type::String => {
+                                let right = preprocess_capture_pred_arg(right, query_store);
+                                Predicate::EqString { left, right }
+                            }
+                            t => todo!("{}", t),
+                        };
+                    } else if t == Type::Spaces {
+                    } else {
+                        todo!()
+                    }
+                }
+                panic!()
+            }
+            l => todo!("{}", l),
+        }
+    }
+}
+
+fn preprocess_capture_pred_arg(
+    arg: hyper_ast::store::nodes::legion::HashedNodeRef<'_, crate::types::TIdN<legion::Entity>>,
+    query_store: &SimpleStores<TStore>,
+) -> String {
+    use crate::types::TIdN;
+    use crate::types::Type;
+    use hyper_ast::types::LabelStore;
+    if let Type::Capture = arg.get_type() {
+        let mut cs = arg.children().unwrap().iter_children();
+        assert_eq!(2, cs.len());
+        let at = cs.next().unwrap();
+        let at = query_store
+            .node_store
+            .try_resolve_typed::<TIdN<NodeIdentifier>>(&at)
+            .unwrap()
+            .0;
+        let t = at.get_type();
+        assert_eq!(t, Type::At);
+        let id = cs.next().unwrap();
+        let id = query_store
+            .node_store
+            .try_resolve_typed::<TIdN<NodeIdentifier>>(&id)
+            .unwrap()
+            .0;
+        let t = id.get_type();
+        assert_eq!(t, Type::Identifier);
+        let l = id.try_get_label();
+        let l = query_store.label_store().resolve(&l.unwrap());
+        l.to_string()
+    } else if let Type::String = arg.get_type() {
+        let l = arg.try_get_label();
+        let l = query_store.label_store().resolve(&l.unwrap());
+        l[1..l.len() - 1].to_string()
+    } else {
+        unreachable!()
+    }
 }
 
 #[derive(Debug)]
 pub(crate) enum Pattern<Ty> {
-    NamedNode { ty: Ty, children: Arc<[Pattern<Ty>]> },
+    NamedNode {
+        ty: Ty,
+        children: Arc<[Pattern<Ty>]>,
+    },
     AnonymousNode(Ty),
+    Capture {
+        name: String,
+        pat: Arc<Pattern<Ty>>,
+    },
+    Predicated {
+        predicate: Predicate,
+        pat: Arc<Pattern<Ty>>,
+    },
 }
+#[derive(Debug)]
+pub(crate) enum Predicate {
+    Eq { left: String, right: String },
+    EqString { left: String, right: String },
+}
+#[derive(Debug)]
+pub(crate) struct MatchingRes {
+    matched: bool,
+    captures: std::collections::HashMap<String, CaptureRes>,
+}
+
+impl MatchingRes {
+    fn fals() -> Self {
+        Self {
+            matched: false,
+            captures: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+pub(crate) enum CaptureRes {
+    Label(String),
+    Node,
+}
+
+impl CaptureRes {
+    pub(crate) fn label(self) -> Option<String> {
+        match self {
+            CaptureRes::Label(l) => Some(l),
+            CaptureRes::Node => None,
+        }
+    }
+}
+
 impl<Ty> Pattern<Ty> {
-    fn is_matching<'store, HAST, TIdN>(&self, code_store: &'store HAST, id: HAST::IdN) -> bool
+    fn is_matching<'store, HAST, TIdN>(
+        &self,
+        code_store: &'store HAST,
+        id: HAST::IdN,
+    ) -> MatchingRes
     where
         HAST: TypedHyperAST<'store, TIdN>,
         TIdN: hyper_ast::types::NodeId<IdN = HAST::IdN>
@@ -267,36 +568,115 @@ impl<Ty> Pattern<Ty> {
     {
         let Some((n, _)) = code_store.typed_node_store().try_resolve(&id) else {
             dbg!();
-            return false;
+            return MatchingRes::fals();
         };
         let t = n.get_type();
-        dbg!(t, self);
-        
+
         match self {
             Pattern::NamedNode { ty, children } => {
                 if *ty != t {
-                    return false;
+                    return MatchingRes::fals();
                 }
                 let Some(cs) = n.children() else {
-                    return children.is_empty()
+                    return MatchingRes {
+                        matched: children.is_empty(),
+                        captures: Default::default(),
+                    };
                 };
                 let mut cs = cs.iter_children();
                 let mut pats = children.iter().peekable();
+                let mut captures = Default::default();
+                if pats.peek().is_none() {
+                    return MatchingRes {
+                        matched: true,
+                        captures,
+                    };
+                }
+                let mut matched = false;
                 loop {
                     let Some(curr_p) = pats.peek() else {
-                        return true
+                        return MatchingRes { matched, captures };
                     };
                     let Some(child) = cs.next() else {
-                        return false
+                        return MatchingRes::fals();
                     };
-                    if curr_p.is_matching(code_store, child.clone()) {
-                        pats.next();
+                    match curr_p.is_matching(code_store, child.clone()) {
+                        MatchingRes {
+                            matched: true,
+                            captures: capt,
+                        } => {
+                            pats.next();
+                            matched = true;
+                            captures.extend(capt);
+                        }
+                        MatchingRes { matched: false, .. } => {}
                     }
                 }
+            }
+            Pattern::AnonymousNode(ty) => MatchingRes {
+                matched: *ty == t,
+                captures: Default::default(),
             },
-            Pattern::AnonymousNode(ty) => *ty == t,
+            Pattern::Capture { name, pat } => match pat.is_matching(code_store, id.clone()) {
+                MatchingRes {
+                    matched: true,
+                    mut captures,
+                } => {
+                    let name = name.clone();
+                    let n = code_store.typed_node_store().try_resolve(&id).unwrap().0;
+                    let v = if n.children().map_or(true, |x| x.is_empty()) {
+                        let l = n.try_get_label().unwrap();
+                        use hyper_ast::types::LabelStore;
+                        let l = code_store.label_store().resolve(l);
+                        CaptureRes::Label(l.to_owned())
+                    } else {
+                        todo!()
+                    };
+                    captures.insert(name, v);
+                    MatchingRes {
+                        matched: true,
+                        captures,
+                    }
+                }
+                MatchingRes { matched: false, .. } => MatchingRes::fals(),
+            },
+            Pattern::Predicated { predicate, pat } => match predicate {
+                Predicate::Eq { left, right } => {
+                    let MatchingRes { matched, captures } = pat.is_matching(code_store, id);
+                    if matched {
+                        let matched = captures
+                            .get(left)
+                            .map_or(false, |x| Some(x) == captures.get(right));
+                        let captures = if matched {
+                            captures
+                        } else {
+                            Default::default()
+                        };
+                        MatchingRes { matched, captures }
+                    } else {
+                        MatchingRes::fals()
+                    }
+                }
+                Predicate::EqString { left, right } => {
+                    let MatchingRes { matched, captures } = pat.is_matching(code_store, id);
+                    if matched {
+                        let Some(CaptureRes::Label(left)) = captures.get(left) else {
+                            return MatchingRes::fals();
+                        };
+                        let matched = left == right;
+                        let captures = if matched {
+                            captures
+                        } else {
+                            Default::default()
+                        };
+                        MatchingRes { matched, captures }
+                    } else {
+                        MatchingRes::fals()
+                    }
+                }
+                p => todo!("{:?}", p),
+            },
         }
-
     }
 }
 
@@ -370,33 +750,33 @@ pub(crate) fn ts_query(text: &[u8]) -> (SimpleStores<crate::types::TStore>, legi
         Ok(t) => t,
         Err(t) => t,
     };
-    println!("{}", tree.root_node().to_sexp());
+    // println!("{}", tree.root_node().to_sexp());
     let full_node = java_tree_gen.generate_file(b"", text, tree.walk());
 
-    println!();
-    println!(
-        "{}",
-        hyper_ast::nodes::SyntaxSerializer::<_, _, true>::new(
-            &*java_tree_gen.stores,
-            full_node.local.compressed_node
-        )
-    );
-    stdout().flush().unwrap();
-    println!(
-        "{}",
-        hyper_ast::nodes::JsonSerializer::<_, _, false>::new(
-            &*java_tree_gen.stores,
-            full_node.local.compressed_node
-        )
-    );
-    stdout().flush().unwrap();
-    println!(
-        "{}",
-        hyper_ast::nodes::TextSerializer::new(
-            &*java_tree_gen.stores,
-            full_node.local.compressed_node
-        )
-    );
-    stdout().flush().unwrap();
+    // println!();
+    // println!(
+    //     "{}",
+    //     hyper_ast::nodes::SyntaxSerializer::<_, _, true>::new(
+    //         &*java_tree_gen.stores,
+    //         full_node.local.compressed_node
+    //     )
+    // );
+    // stdout().flush().unwrap();
+    // println!(
+    //     "{}",
+    //     hyper_ast::nodes::JsonSerializer::<_, _, false>::new(
+    //         &*java_tree_gen.stores,
+    //         full_node.local.compressed_node
+    //     )
+    // );
+    // stdout().flush().unwrap();
+    // println!(
+    //     "{}",
+    //     hyper_ast::nodes::TextSerializer::new(
+    //         &*java_tree_gen.stores,
+    //         full_node.local.compressed_node
+    //     )
+    // );
+    // stdout().flush().unwrap();
     (stores, full_node.local.compressed_node)
 }

--- a/gen/tree-sitter/query/src/tests/auto.rs
+++ b/gen/tree-sitter/query/src/tests/auto.rs
@@ -1,0 +1,693 @@
+use hyper_ast::{
+    position::{position_accessors::WithPreOrderOffsets, StructuralPosition, TreePath},
+    store::{defaults::NodeIdentifier, nodes::legion::NodeStore, SimpleStores},
+    types::{IterableChildren, Labeled, Typed, WithChildren},
+};
+use hyper_ast_gen_ts_cpp::legion::CppTreeGen;
+
+const C0: &str = r#"int f() {
+    return 21 + 21;
+}"#;
+
+const C1: &str = r#"int f() {
+    return 21 - 21;
+}"#;
+
+const C2: &str = r#"int f() {
+    int a = 21;
+    return a + a;
+}"#;
+
+const C3: &str = r#"int f() {
+    int a = 21;
+    int b = 21;
+    return a + b;
+}"#;
+
+const C4: &str = r#"int f() {
+    int b = 21;
+    return b + b;
+}"#;
+
+// Possible useful stuff:
+// - test if subtree is conforming to ts query
+//   - initially for each node in subtree, do the test
+//     - terminate on wrong root type as fast as possible
+//   - after that find different oracles
+//     - type oracle
+//     - structure hash oracle
+//     - filtered structure hash oracle
+//     - other convolutions (including prev hashes)
+//     - labels through bags of words and defered bloom filters computing
+// - edit distance between query and subtree
+// - acceleration related to extracting entropy from basic constructs
+
+#[test]
+fn gen_match_simple() {
+    let (code_store, code) = cpp_tree(C0.as_bytes());
+    let pat = code;
+    let pat = code_store.node_store.resolve(pat).child(&0).unwrap();
+    let pat = code_store.node_store.resolve(pat).child(&4).unwrap();
+    let pat = code_store.node_store.resolve(pat).child(&2).unwrap();
+    let pat = code_store.node_store.resolve(pat).child(&2).unwrap();
+    println!();
+    println!(
+        "{}",
+        hyper_ast::nodes::SyntaxSerializer::<_, _, true>::new(&code_store, pat)
+    );
+    println!();
+    println!(
+        "{}",
+        hyper_ast::nodes::TextSerializer::new(&code_store, pat)
+    );
+    println!();
+    let q0 =
+        tsq_ser::TreeToQuery::<_, _, true, true, false, false>::new(&code_store, pat).to_string();
+    println!("{}", q0);
+    let (query_store, query) = crate::search::ts_query(q0.as_bytes());
+
+    {
+        let path = hyper_ast::position::StructuralPosition::new(code);
+        let prepared_matcher =
+            crate::search::PreparedMatcher::<_, hyper_ast_gen_ts_cpp::types::Type>::new(
+                &query_store,
+                query,
+            );
+        let mut matched = false;
+        for e in hyper_ast_gen_ts_cpp::iter::IterAll::new(&code_store, path, code) {
+            if prepared_matcher.is_matching::<_, hyper_ast_gen_ts_cpp::types::TIdN<NodeIdentifier>>(
+                &code_store,
+                *e.node().unwrap(),
+            ) {
+                type T =
+                    hyper_ast_gen_ts_cpp::types::TIdN<hyper_ast::store::defaults::NodeIdentifier>;
+                let n = code_store
+                    .node_store
+                    .try_resolve_typed::<T>(e.node().unwrap())
+                    .unwrap()
+                    .0;
+                let t = n.get_type();
+                dbg!(t);
+                matched = true;
+            }
+        }
+        assert!(matched);
+    }
+    {
+        let (code_store1, code1) = cpp_tree(C1.as_bytes());
+        let path = hyper_ast::position::StructuralPosition::new(code1);
+        let prepared_matcher =
+            crate::search::PreparedMatcher::<_, hyper_ast_gen_ts_cpp::types::Type>::new(
+                &query_store,
+                query,
+            );
+        for e in hyper_ast_gen_ts_cpp::iter::IterAll::new(&code_store1, path, code1) {
+            if prepared_matcher.is_matching::<_, hyper_ast_gen_ts_cpp::types::TIdN<NodeIdentifier>>(
+                &code_store1,
+                *e.node().unwrap(),
+            ) {
+                type T =
+                    hyper_ast_gen_ts_cpp::types::TIdN<hyper_ast::store::defaults::NodeIdentifier>;
+                let n = code_store1
+                    .node_store
+                    .try_resolve_typed::<T>(e.node().unwrap())
+                    .unwrap()
+                    .0;
+                let t = n.get_type();
+                dbg!(t);
+                panic!("should not match")
+            }
+        }
+    }
+}
+
+#[test]
+fn gen_match_named() {
+    let (code_store, code) = cpp_tree(C2.as_bytes());
+    println!(
+        "\nThe code:\n{}",
+        hyper_ast::nodes::TextSerializer::new(&code_store, code)
+    );
+    let pat = code;
+    let pat = code_store.node_store.resolve(pat).child(&0).unwrap();
+    let pat = code_store.node_store.resolve(pat).child(&4).unwrap();
+    let pat = code_store.node_store.resolve(pat).child(&4).unwrap();
+    let pat = code_store.node_store.resolve(pat).child(&2).unwrap();
+    println!(
+        "\nThe subtree:\n{}",
+        hyper_ast::nodes::TextSerializer::new(&code_store, pat)
+    );
+    let q0 =
+        tsq_ser::TreeToQuery::<_, _, true, true, false, false>::new(&code_store, pat).to_string();
+    println!("\nThe corresponding query:\n{}", q0);
+    let (mut query_store, query) = crate::search::ts_query(q0.as_bytes());
+
+    let path = hyper_ast::position::StructuralPosition::new(code);
+    let prepared_matcher =
+        crate::search::PreparedMatcher::<_, hyper_ast_gen_ts_cpp::types::Type>::new(
+            &query_store,
+            query,
+        );
+    let mut matched = false;
+    for e in hyper_ast_gen_ts_cpp::iter::IterAll::new(&code_store, path, code) {
+        if prepared_matcher.is_matching::<_, hyper_ast_gen_ts_cpp::types::TIdN<NodeIdentifier>>(
+            &code_store,
+            *e.node().unwrap(),
+        ) {
+            println!("\nThe matched subtree:");
+            println!(
+                "{}",
+                hyper_ast::nodes::TextSerializer::new(&code_store, *e.node().unwrap())
+            );
+            matched = true;
+        }
+    }
+    assert!(matched);
+    // Negative case
+    let (code_store1, code1) = cpp_tree(C3.as_bytes());
+    println!(
+        "\nThe second code:\n{}",
+        hyper_ast::nodes::TextSerializer::new(&code_store1, code1)
+    );
+    let path = hyper_ast::position::StructuralPosition::new(code1);
+    let prepared_matcher =
+        crate::search::PreparedMatcher::<_, hyper_ast_gen_ts_cpp::types::Type>::new(
+            &query_store,
+            query,
+        );
+    for e in hyper_ast_gen_ts_cpp::iter::IterAll::new(&code_store1, path, code1) {
+        if prepared_matcher.is_matching::<_, hyper_ast_gen_ts_cpp::types::TIdN<NodeIdentifier>>(
+            &code_store1,
+            *e.node().unwrap(),
+        ) {
+            panic!("should not match")
+        }
+    }
+
+    println!("(Good) The initial query does not match the second code");
+
+    let (code_store2, code2) = cpp_tree(C4.as_bytes());
+    println!(
+        "\nThe third code (initial code with a rename):\n{}",
+        hyper_ast::nodes::TextSerializer::new(&code_store2, code2)
+    );
+
+    let path = hyper_ast::position::StructuralPosition::new(code2);
+    let prepared_matcher =
+        crate::search::PreparedMatcher::<_, hyper_ast_gen_ts_cpp::types::Type>::new(
+            &query_store,
+            query,
+        );
+    for e in hyper_ast_gen_ts_cpp::iter::IterAll::new(&code_store2, path, code2) {
+        if prepared_matcher.is_matching::<_, hyper_ast_gen_ts_cpp::types::TIdN<NodeIdentifier>>(
+            &code_store2,
+            *e.node().unwrap(),
+        ) {
+            panic!("should not match")
+        }
+    }
+    println!("(Expected) The initial query does not match the third code");
+    println!("Lets make the initial query more generic");
+
+    const M0: &str = r#"(predicate (identifier) @op (#eq? @op "eq") (parameters (capture (identifier) @id ) (string) @label ))"#;
+    println!("");
+    println!("\nThe meta query:\n{}", M0);
+    let (query_store1, query1) = crate::search::ts_query(M0.as_bytes());
+
+    let path = hyper_ast::position::StructuralPosition::new(query);
+    let prepared_matcher =
+        crate::search::PreparedMatcher::<_, crate::types::Type>::new(&query_store1, query1);
+    let mut per_label = std::collections::HashMap::<
+        String,
+        Vec<(String, StructuralPosition<NodeIdentifier, u16>)>,
+    >::default();
+    for e in crate::iter::IterAll::new(&query_store, path, query) {
+        if let Some(capts) = prepared_matcher
+            .is_matching_and_capture::<_, crate::types::TIdN<NodeIdentifier>>(
+                &query_store,
+                *e.node().unwrap(),
+            )
+        {
+            dbg!(&capts);
+            let k = capts.get("label").unwrap().clone().label().unwrap();
+            let v = capts.get("id").unwrap().clone().label().unwrap();
+            let p = e;
+            per_label.entry(k).or_insert(vec![]).push((v, p));
+        }
+    }
+    assert_eq!(1, per_label.len());
+    dbg!(&per_label);
+    struct PerLabel(
+        std::collections::HashMap<String, Vec<(String, StructuralPosition<NodeIdentifier, u16>)>>,
+    );
+
+    impl std::fmt::Display for PerLabel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            for x in self.0.values() {
+                if x.len() == 2 {
+                    writeln!(f, "(#eq? @{} @{})", x[0].0, x[1].0)?;
+                    dbg!(x[0].1.shared_ancestors(&x[1].1));
+                } else if x.len() == 1 {
+                    // noop
+                } else {
+                    todo!("need to do combination")
+                }
+            }
+            Ok(())
+        }
+    }
+
+    let query_bis = tsq_transform::regen_query(
+        &mut query_store,
+        query,
+        vec![
+            tsq_transform::Action::Delete {
+                path: per_label.get("\"a\"").unwrap()[0]
+                    .1
+                    .iter_offsets()
+                    .collect(),
+            },
+            tsq_transform::Action::Delete {
+                path: per_label.get("\"a\"").unwrap()[1]
+                    .1
+                    .iter_offsets()
+                    .collect(),
+            },
+        ],
+    );
+
+    println!(
+        "\nAgain the third code (initial code with a rename):\n{}",
+        hyper_ast::nodes::TextSerializer::new(&code_store2, code2)
+    );
+
+    let qbis = hyper_ast::nodes::TextSerializer::<_, _>::new(&query_store, query_bis).to_string();
+    let qbis = format!("{} {}", qbis, PerLabel(per_label.clone()));
+    println!("\nThe generified query:\n{}", qbis);
+    let (query_store, query) = crate::search::ts_query(qbis.as_bytes());
+
+    {
+        let path = hyper_ast::position::StructuralPosition::new(code2);
+        let prepared_matcher =
+            crate::search::PreparedMatcher::<_, hyper_ast_gen_ts_cpp::types::Type>::new(
+                &query_store,
+                query,
+            );
+        let mut matched = false;
+        for e in hyper_ast_gen_ts_cpp::iter::IterAll::new(&code_store2, path, code2) {
+            if prepared_matcher.is_matching::<_, hyper_ast_gen_ts_cpp::types::TIdN<NodeIdentifier>>(
+                &code_store2,
+                *e.node().unwrap(),
+            ) {
+                println!("\nThe matched subtree with a rename:");
+                println!(
+                    "{}",
+                    hyper_ast::nodes::TextSerializer::new(&code_store2, *e.node().unwrap())
+                );
+                matched = true;
+            }
+        }
+        assert!(matched);
+    }
+}
+
+fn cpp_tree(
+    text: &[u8],
+) -> (
+    SimpleStores<hyper_ast_gen_ts_cpp::types::TStore>,
+    legion::Entity,
+) {
+    use hyper_ast_gen_ts_cpp::types::TStore;
+    let tree = match CppTreeGen::<TStore>::tree_sitter_parse(text) {
+        Ok(t) => t,
+        Err(t) => t,
+    };
+    // println!("{:#?}", tree.root_node().to_sexp());
+    let mut stores: SimpleStores<TStore> = SimpleStores::default();
+    let mut md_cache = Default::default();
+    let mut tree_gen = CppTreeGen {
+        line_break: "\n".as_bytes().to_vec(),
+        stores: &mut stores,
+        md_cache: &mut md_cache,
+    };
+    let x = tree_gen.generate_file(b"", text, tree.walk()).local;
+    let entity = x.compressed_node;
+    // println!(
+    //     "{}",
+    //     hyper_ast::nodes::SyntaxSerializer::<_, _, true>::new(&stores, entity)
+    // );
+    (stores, entity)
+}
+
+mod tsq_ser {
+
+    use hyper_ast::nodes::Space;
+    use hyper_ast::types::HyperType;
+    use hyper_ast::types::IterableChildren;
+    use hyper_ast::types::{self, NodeId};
+    use std::fmt::{Debug, Display, Write};
+
+    pub struct TreeToQuery<
+        'a,
+        IdN,
+        HAST,
+        const TY: bool = true,
+        const LABELS: bool = false,
+        const IDS: bool = false,
+        const SPC: bool = false,
+    > {
+        stores: &'a HAST,
+        root: IdN,
+    }
+
+    impl<
+            'store,
+            IdN,
+            HAST,
+            const TY: bool,
+            const LABELS: bool,
+            const IDS: bool,
+            const SPC: bool,
+        > TreeToQuery<'store, IdN, HAST, TY, LABELS, IDS, SPC>
+    {
+        pub fn new(stores: &'store HAST, root: IdN) -> Self {
+            Self { stores, root }
+        }
+    }
+
+    impl<
+            'store,
+            IdN,
+            HAST,
+            const TY: bool,
+            const LABELS: bool,
+            const IDS: bool,
+            const SPC: bool,
+        > Display for TreeToQuery<'store, IdN, HAST, TY, LABELS, IDS, SPC>
+    where
+        IdN: NodeId<IdN = IdN> + Debug,
+        HAST: types::NodeStore<IdN>,
+        HAST: types::LabelStore<str>,
+        HAST: types::TypeStore<HAST::R<'store>>,
+        HAST::R<'store>: types::Labeled<Label = HAST::I> + types::WithChildren<TreeId = IdN>,
+    {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.serialize(&self.root, &mut 0, f).map(|_| ())
+        }
+    }
+
+    impl<
+            'store,
+            IdN,
+            HAST,
+            const TY: bool,
+            const LABELS: bool,
+            const IDS: bool,
+            const SPC: bool,
+        > TreeToQuery<'store, IdN, HAST, TY, LABELS, IDS, SPC>
+    where
+        IdN: NodeId<IdN = IdN> + Debug,
+        HAST: types::NodeStore<IdN>,
+        HAST: types::LabelStore<str>,
+        HAST: types::TypeStore<HAST::R<'store>>,
+        HAST::R<'store>: types::Labeled<Label = HAST::I> + types::WithChildren<TreeId = IdN>,
+    {
+        // pub fn tree_syntax_with_ids(
+        fn serialize(
+            &self,
+            id: &IdN,
+            mut count: &mut usize,
+            out: &mut std::fmt::Formatter<'_>,
+        ) -> Result<(), std::fmt::Error> {
+            const LABELS0: bool = false;
+            use types::LabelStore;
+            use types::Labeled;
+            use types::NodeStore;
+            use types::WithChildren;
+            let b = NodeStore::resolve(self.stores, id);
+            // let kind = (self.stores.type_store(), b);
+            let kind = self.stores.resolve_type(&b);
+            let label = b.try_get_label();
+            let children = b.children();
+
+            if kind.is_spaces() {
+                if SPC {
+                    let s = LabelStore::resolve(self.stores, &label.unwrap());
+                    let b: String = Space::format_indentation(s.as_bytes())
+                        .iter()
+                        .map(|x| x.to_string())
+                        .collect();
+                    write!(out, "(")?;
+                    if IDS { write!(out, "{:?}", id) } else { Ok(()) }.and_then(|x| {
+                        if TY {
+                            write!(out, "_",)
+                        } else {
+                            Ok(x)
+                        }
+                    })?;
+                    if LABELS0 {
+                        write!(out, " {:?}", Space::format_indentation(b.as_bytes()))?;
+                    }
+                    write!(out, ")")?;
+                }
+                return Ok(());
+            }
+
+            let w_kind = |out: &mut std::fmt::Formatter<'_>| {
+                if IDS { write!(out, "{:?}", id) } else { Ok(()) }.and_then(|x| {
+                    if TY {
+                        write!(out, "{}", kind.to_string())
+                    } else {
+                        Ok(x)
+                    }
+                })
+            };
+
+            match (label, children) {
+                (None, None) => {
+                    // w_kind(out)?;
+                    if IDS { write!(out, "{:?}", id) } else { Ok(()) }.and_then(|x| {
+                        if TY {
+                            write!(out, "\"{}\"", kind.to_string())
+                        } else {
+                            Ok(x)
+                        }
+                    })?;
+                }
+                (label, Some(children)) => {
+                    if let Some(label) = label {
+                        let s = LabelStore::resolve(self.stores, label);
+                        if LABELS0 {
+                            write!(out, " {:?}", Space::format_indentation(s.as_bytes()))?;
+                        }
+                    }
+                    if !children.is_empty() {
+                        let it = children.iter_children();
+                        write!(out, "(")?;
+                        w_kind(out)?;
+                        for id in it {
+                            write!(out, " ")?;
+                            self.serialize(&id, count, out)?;
+                        }
+                        write!(out, ")")?;
+                    }
+                }
+                (Some(label), None) => {
+                    write!(out, "(")?;
+                    w_kind(out)?;
+                    if LABELS0 {
+                        let s = LabelStore::resolve(self.stores, label);
+                        if s.len() > 20 {
+                            write!(out, "='{}...'", &s[..20])?;
+                        } else {
+                            write!(out, "='{}'", s)?;
+                        }
+                    }
+                    write!(out, ")")?;
+                    if LABELS {
+                        let s = LabelStore::resolve(self.stores, label);
+                        write!(out, " @id{} (#eq? @id{} \"{}\")", count, count, s)?;
+                        *count += 1;
+                    }
+                }
+            }
+            return Ok(());
+        }
+    }
+
+    fn escape(src: &str) -> String {
+        let mut escaped = String::with_capacity(src.len());
+        let mut utf16_buf = [0u16; 2];
+        for c in src.chars() {
+            match c {
+                ' ' => escaped += " ",
+                '\x08' => escaped += "\\b",
+                '\x0c' => escaped += "\\f",
+                '\n' => escaped += "\\n",
+                '\r' => escaped += "\\r",
+                '\t' => escaped += "\\t",
+                '"' => escaped += "\\\"",
+                '\\' => escaped += "\\\\",
+                c if c.is_ascii_graphic() => escaped.push(c),
+                c => {
+                    let encoded = c.encode_utf16(&mut utf16_buf);
+                    for utf16 in encoded {
+                        write!(&mut escaped, "\\u{:04X}", utf16).unwrap();
+                    }
+                }
+            }
+        }
+        escaped
+    }
+}
+
+mod tsq_transform {
+    use hyper_ast::{
+        PrimInt,
+        store::{defaults::NodeIdentifier, SimpleStores},
+        types::{IterableChildren, Labeled, Typed},
+    };
+
+    use crate::types::TIdN;
+
+    pub enum Action<Idx> {
+        Delete { path: Vec<Idx> },
+    }
+    type Idx = u16;
+    pub(crate) fn regen_query(
+        ast: &mut SimpleStores<crate::types::TStore>,
+        root: NodeIdentifier,
+        actions: Vec<Action<Idx>>,
+    ) -> NodeIdentifier {
+        let mut md_cache = Default::default();
+        let mut query_tree_gen = crate::legion::TsQueryTreeGen {
+            line_break: "\n".as_bytes().to_vec(),
+            stores: ast,
+            md_cache: &mut md_cache,
+        };
+        #[derive(PartialEq, Debug)]
+        enum ActionTree<Idx> {
+            Delete,
+            Children(Vec<(Idx, ActionTree<Idx>)>),
+        }
+        impl<Idx: std::cmp::PartialOrd + Clone + PrimInt> From<Vec<Action<Idx>>> for ActionTree<Idx> {
+            fn from(value: Vec<Action<Idx>>) -> Self {
+                let mut res = ActionTree::Children(vec![]);
+                fn insert<Idx: std::cmp::PartialOrd + Clone + PrimInt>(
+                    s: &mut ActionTree<Idx>,
+                    a: Action<Idx>,
+                ) {
+                    match a {
+                        Action::Delete { path } if path.is_empty() => {
+                            *s = ActionTree::Delete;
+                        }
+                        Action::Delete { mut path } => {
+                            let ActionTree::Children(cs) = s else {
+                                panic!()
+                            };
+                            // dbg!(&cs);
+                            let p = path.pop().unwrap();
+                            let mut low = 0;
+                            let mut high = cs.len();
+                            loop {
+                                if low == high {
+                                    let mut c = ActionTree::Children(vec![]);
+                                    insert(&mut c, Action::Delete { path });
+                                    cs.insert(low, (p, c));
+                                    break;
+                                }
+                                let mid = low + (high - low) / 2;
+                                if cs[mid].0 == p {
+                                    insert(&mut cs[mid].1, Action::Delete { path });
+                                    break;
+                                } else if p < cs[mid].0 {
+                                    high = mid.saturating_sub(1);
+                                } else {
+                                    low = mid + 1;
+                                }
+                            }
+                        }
+                    }
+                }
+                for a in value {
+                    let a = match a {
+                        Action::Delete { mut path } => {
+                            path.reverse();
+                            Action::Delete { path }
+                        }
+                    };
+                    insert(&mut res, a);
+                }
+                fn offsetify<Idx: PrimInt>(s: &mut ActionTree<Idx>) {
+                    let mut i = num::zero();
+                    if let ActionTree::Children(cs) = s {
+                        for (j, c) in cs {
+                            let tmp = i;
+                            i = *j + num::one();
+                            *j -= tmp;
+                            offsetify(c);
+                        }
+                    }
+                }
+                // dbg!(&res);
+                offsetify(&mut res);
+                res
+            }
+        }
+        let actions = ActionTree::from(actions);
+        fn apply(
+            ast: &mut crate::legion::TsQueryTreeGen<'_, '_, crate::types::TStore>,
+            a: ActionTree<Idx>,
+            c: NodeIdentifier,
+        ) -> NodeIdentifier {
+            // dbg!(c);
+            let (t, n) = ast
+                .stores
+                .node_store
+                .resolve_with_type::<TIdN<NodeIdentifier>>(&c);
+            // dbg!(t);
+            // println!(
+            //     "{}",
+            //     hyper_ast::nodes::SyntaxSerializer::<_, _, false>::new(ast.stores, c)
+            // );
+            let l = n.try_get_label().copied();
+            let mut cs: Vec<NodeIdentifier> = vec![];
+            use hyper_ast::types::WithChildren;
+
+            let cs_nodes = n
+                .children()
+                .unwrap()
+                .iter_children()
+                .copied()
+                .collect::<Vec<_>>();
+            let mut cs_nodes = cs_nodes.iter();
+            drop(n);
+
+            let ActionTree::Children(child_actions) = a else {
+                panic!()
+            };
+            for (mut o, a) in child_actions {
+                // dbg!(&a);
+                match a {
+                    ActionTree::Delete => {
+                        while o > 0 {
+                            cs.push(cs_nodes.next().unwrap().to_owned());
+                            o -= 1;
+                        }
+                        cs_nodes.next().unwrap();
+                    }
+                    a => cs.push(apply(ast, a, *cs_nodes.next().unwrap())),
+                }
+            }
+            cs.extend(cs_nodes);
+            ast.build_then_insert(c, t, l, cs)
+        }
+        assert_ne!(
+            actions,
+            ActionTree::Delete,
+            "it makes no sense to remove the entire tree"
+        );
+        // dbg!(&actions);
+        apply(&mut query_tree_gen, actions, root)
+    }
+}

--- a/gen/tree-sitter/query/src/tests/mod.rs
+++ b/gen/tree-sitter/query/src/tests/mod.rs
@@ -54,3 +54,4 @@ fn run(text: &[u8]) {
 }
 
 mod search;
+mod auto;

--- a/gen/tree-sitter/query/src/types.rs
+++ b/gen/tree-sitter/query/src/types.rs
@@ -342,6 +342,16 @@ impl Display for Type {
     }
 }
 
+
+
+impl TryFrom<&str> for Type {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Type::from_str(value).ok_or_else(|| value.to_owned())
+    }
+}
+
 #[repr(u16)]
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub enum Type {

--- a/hyper_app/src/app/tree_view.rs
+++ b/hyper_app/src/app/tree_view.rs
@@ -38,19 +38,19 @@ impl<'a> hyper_ast::types::TypeStore<HashedNodeRef<'a, NodeIdentifier>> for TSto
     fn resolve_type(&self, n: &HashedNodeRef<'a, NodeIdentifier>) -> Self::Ty {
         let lang = n.get_lang();
         let t: &'static (dyn HyperType + 'static) = match lang {
-            "hyper_ast_gen_ts_cpp::types::Cpp" => {
+            "hyper_ast_gen_ts_cpp::types::Lang" => {
                 let raw = n.get_raw_type();
                 let t: &'static (dyn HyperType + 'static) =
                     <hyper_ast_gen_ts_cpp::types::Cpp as Lang<_>>::make(raw);
                 t
             }
-            "hyper_ast_gen_ts_java::types::Java" => {
+            "hyper_ast_gen_ts_java::types::Lang" => {
                 let raw = n.get_raw_type();
                 let t: &'static (dyn HyperType + 'static) =
                     <hyper_ast_gen_ts_java::types::Java as Lang<_>>::make(raw);
                 t
             }
-            "hyper_ast_gen_ts_xml::types::Xml" => {
+            "hyper_ast_gen_ts_xml::types::Lang" => {
                 let raw = n.get_raw_type();
                 let t: &'static (dyn HyperType + 'static) =
                     <hyper_ast_gen_ts_xml::types::Xml as Lang<_>>::make(raw);
@@ -75,17 +75,17 @@ impl<'a> hyper_ast::types::TypeStore<HashedNodeRef<'a, NodeIdentifier>> for TSto
     ) -> hyper_ast::types::LangWrapper<Self::Ty> {
         let lang = n.get_lang();
         let t = match lang {
-            "hyper_ast_gen_ts_cpp::types::Cpp" => {
-                From::<&'static (dyn LangRef<AnyType>)>::from(&hyper_ast_gen_ts_cpp::types::Cpp)
+            "hyper_ast_gen_ts_cpp::types::Lang" => {
+                From::<&'static (dyn LangRef<AnyType>)>::from(&hyper_ast_gen_ts_cpp::types::Lang)
             }
-            "hyper_ast_gen_ts_java::types::Java" => {
-                From::<&'static (dyn LangRef<AnyType>)>::from(&hyper_ast_gen_ts_java::types::Java)
+            "hyper_ast_gen_ts_java::types::Lang" => {
+                From::<&'static (dyn LangRef<AnyType>)>::from(&hyper_ast_gen_ts_java::types::Lang)
             }
-            "hyper_ast_gen_ts_xml::types::Xml" => {
-                From::<&'static (dyn LangRef<AnyType>)>::from(&hyper_ast_gen_ts_xml::types::Xml)
+            "hyper_ast_gen_ts_xml::types::Lang" => {
+                From::<&'static (dyn LangRef<AnyType>)>::from(&hyper_ast_gen_ts_xml::types::Lang)
             }
             "" => {
-                From::<&'static (dyn LangRef<AnyType>)>::from(&hyper_ast_gen_ts_java::types::Java)
+                From::<&'static (dyn LangRef<AnyType>)>::from(&hyper_ast_gen_ts_java::types::Lang)
             }
             // "xml" => From::<&'static (dyn LangRef<AnyType>)>::from(&hyper_ast_gen_ts_xml::types::Xml),
             x => panic!("{}", x),

--- a/hyper_ast/src/hashed.rs
+++ b/hyper_ast/src/hashed.rs
@@ -3,11 +3,11 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use crate::types::{AnyType, HashKind, HyperType, MySlice, NodeId};
+use crate::{types::{AnyType, HashKind, HyperType, MySlice, NodeId}, PrimInt};
 use crate::{
     store::labels::DefaultLabelIdentifier, store::nodes::DefaultNodeIdentifier, types::Type,
 };
-use num::{traits::WrappingAdd, PrimInt};
+use num::{traits::WrappingAdd};
 
 use crate::nodes::{CompressedNode, HashSize};
 

--- a/hyper_ast/src/lib.rs
+++ b/hyper_ast/src/lib.rs
@@ -17,5 +17,8 @@ pub mod types;
 pub mod usage;
 pub mod utils;
 
+pub trait PrimInt: num::PrimInt + num::traits::NumAssign + std::fmt::Debug {}
+impl<T> PrimInt for T where T: num::PrimInt + num::traits::NumAssign + std::fmt::Debug {}
+
 #[cfg(test)]
 mod tests;

--- a/hyper_ast/src/position.rs
+++ b/hyper_ast/src/position.rs
@@ -87,6 +87,10 @@ pub mod position_accessors {
         fn root(&self) -> IdN;
     }
 
+    pub trait AssistedFrom<S, T> {
+        fn compute(&self, store: S) -> T;
+    }
+
     pub trait SolvedPosition<IdN> {
         fn node(&self) -> IdN;
     }
@@ -113,8 +117,8 @@ pub mod position_accessors {
     pub trait WithPreOrderOffsets: WithOffsets {
         // type Path: Iterator;
         // fn path(&self) -> Self::Path;
-        type It: Iterator<Item = Self::Idx>;
-        fn iter(&self) -> Self::It;
+        type It<'a>: Iterator<Item = &'a Self::Idx> where Self: 'a, Self::Idx: 'a;
+        fn iter_offsets(&self) -> Self::It<'_>;
     }
 
     /// test invariants with [assert_invariants_pre]
@@ -141,10 +145,10 @@ pub mod position_accessors {
         let root = p.root();
         let mut prev = root.clone();
         let it = p.iter_offsets_and_nodes();
-        let snd_it = p.iter();
+        let snd_it = p.iter_offsets();
         set.insert(root);
         for ((o0, x), o1) in it.into_iter().zip(snd_it) {
-            assert_eq!(o0, o1);
+            assert_eq!(o0, *o1);
             if !set.insert(x.clone()) {
                 panic!("path returns 2 times the same node")
             }
@@ -259,6 +263,17 @@ pub mod position_accessors {
         fn start(&self) -> Self::IdO;
         fn end(&self) -> Self::IdO;
     }
+    pub trait OffsetPostionT<IdN>
+    where
+        Self::IdO: PrimInt,
+    {
+        /// Offset in characters or bytes
+        type IdO;
+        fn offset(&self) -> Self::IdO;
+        fn len(&self) -> Self::IdO;
+        fn start(&self) -> Self::IdO;
+        fn end(&self) -> Self::IdO;
+    }
 }
 
 pub struct PositionConverter<'src, SrcPos> {
@@ -327,7 +342,7 @@ mod computing_offset_bottom_up;
 // pub use computing_offset_bottom_up::{extract_file_postion, extract_position};
 
 mod computing_offset_top_down;
-pub use computing_offset_top_down::{compute_position, compute_position_and_nodes, compute_range};
+pub use computing_offset_top_down::{compute_position, compute_position_and_nodes, compute_position_and_nodes2, compute_position_and_nodes3, compute_range};
 
 mod computing_path;
 pub use computing_path::resolve_range;

--- a/hyper_ast/src/position/building.rs
+++ b/hyper_ast/src/position/building.rs
@@ -194,7 +194,7 @@ pub struct CompoundPositionPreparer<A, B>(A, B);
 mod impl_c_p_p_receivers2 {
 
     use super::super::file_and_offset::Position;
-    use super::super::PrimInt;
+    use crate::PrimInt;
     use super::bottom_up;
     use super::top_down;
     use super::CompoundPositionPreparer;

--- a/hyper_ast/src/position/computing_offset_top_down.rs
+++ b/hyper_ast/src/position/computing_offset_top_down.rs
@@ -198,6 +198,37 @@ where
     (Position::new(file, offset, len), path_ids)
 }
 
+pub fn compute_position_and_nodes2<'store, HAST, It: Iterator>(
+    root: HAST::IdN,
+    offsets: &mut It,
+    stores: &HAST,
+) -> (Position, Vec<HAST::IdN>)
+where
+    It::Item: Clone,
+    HAST: 'store + crate::types::HyperASTShared,
+    HAST::IdN: Clone,
+    &'store HAST: crate::types::HyperASTLean,
+    // for<'a> &'a <&'store HAST as crate::types::HyperASTLean>::NS<'store>: 
+    //     crate::types::NodeStoreLean<<&'store HAST as crate::types::HyperASTShared>::IdN, R = <&'store HAST as crate::types::HyperASTLean>::T>,
+    <&'store HAST as crate::types::HyperASTLean>::T: WithSerialization + WithChildren<ChildIdx = It::Item>,
+{
+    todo!()
+}
+
+pub fn compute_position_and_nodes3<'store, HAST, It: Iterator>(
+    root: HAST::IdN,
+    offsets: &mut It,
+    stores: &HAST,
+) -> (Position, Vec<HAST::IdN>)
+where
+    It::Item: Clone,
+    HAST: 'store + crate::types::HyperASTShared + crate::types::HyperASTAsso,
+    HAST::IdN: Clone,
+    HAST::T<'store>: WithSerialization + WithChildren<ChildIdx = It::Item>,
+{
+    todo!()
+}
+
 impl StructuralPosition<NodeIdentifier, u16> {
     pub fn make_position<'store, HAST>(&self, stores: &'store HAST) -> Position
     where

--- a/hyper_ast/src/position/computing_offset_top_down.rs
+++ b/hyper_ast/src/position/computing_offset_top_down.rs
@@ -2,7 +2,8 @@
 
 use num::ToPrimitive;
 
-use super::{Position, PrimInt, StructuralPosition, TreePath};
+use super::{Position, StructuralPosition, TreePath};
+use crate::PrimInt;
 use std::path::PathBuf;
 
 use crate::{

--- a/hyper_ast/src/position/file_and_offset.rs
+++ b/hyper_ast/src/position/file_and_offset.rs
@@ -4,7 +4,7 @@ use std::{
     path::PathBuf,
 };
 
-use super::PrimInt;
+use crate::PrimInt;
 
 #[derive(PartialEq, Eq, Hash, Clone, Default)]
 pub struct Position<F, T: PrimInt> {
@@ -127,7 +127,7 @@ mod impl_receivers {
     use super::super::building;
     use building::top_down;
     use building::bottom_up;
-    use super::super::PrimInt;
+    use crate::PrimInt;
 
 
     impl<IdO: PrimInt> top_down::CreateBuilder for super::Position<PathBuf, IdO> {

--- a/hyper_ast/src/position/offsets.rs
+++ b/hyper_ast/src/position/offsets.rs
@@ -64,10 +64,10 @@ impl<'a, IdN: Copy, Idx: PrimInt> position_accessors::WithOffsets
 impl<'a, IdN: Copy, Idx: PrimInt> position_accessors::WithPreOrderOffsets
     for RootedOffsetsRef<'a, IdN, Idx>
 {
-    type It = std::iter::Copied<std::slice::Iter<'a, Idx>>;
+    type It<'b> = std::slice::Iter<'b, Idx> where Self: 'b, Idx: 'b;
 
-    fn iter(&self) -> Self::It {
-        self.offsets.iter().copied()
+    fn iter_offsets(&self) -> Self::It<'_> {
+        self.offsets.iter()
     }
 }
 

--- a/hyper_ast/src/position/offsets.rs
+++ b/hyper_ast/src/position/offsets.rs
@@ -1,6 +1,8 @@
 use std::marker::PhantomData;
 
-use super::{position_accessors, tags, PrimInt};
+use crate::PrimInt;
+
+use super::{position_accessors, tags};
 
 // TODO remove PrimInt, also in impls
 pub struct Offsets<Idx: PrimInt, Config = tags::TopDownFull> {
@@ -64,10 +66,10 @@ impl<'a, IdN: Copy, Idx: PrimInt> position_accessors::WithOffsets
 impl<'a, IdN: Copy, Idx: PrimInt> position_accessors::WithPreOrderOffsets
     for RootedOffsetsRef<'a, IdN, Idx>
 {
-    type It<'b> = std::slice::Iter<'b, Idx> where Self: 'b, Idx: 'b;
+    type It<'b> = std::iter::Copied<std::slice::Iter<'b, Idx>> where Self: 'b, Idx: 'b;
 
     fn iter_offsets(&self) -> Self::It<'_> {
-        self.offsets.iter()
+        self.offsets.iter().copied()
     }
 }
 
@@ -90,7 +92,7 @@ pub(super) struct SolvedPathPosition<IdN, Idx> {
 mod impl_receivers {
     use super::super::building;
     use building::top_down;
-    use super::super::PrimInt;
+    use crate::PrimInt;
     use super::tags;
     use super::Offsets;
 

--- a/hyper_ast/src/position/offsets_and_nodes.rs
+++ b/hyper_ast/src/position/offsets_and_nodes.rs
@@ -1,6 +1,6 @@
-use super::{PrimInt, TreePath, TreePathMut, tags};
-
+use super::{tags, TreePath, TreePathMut};
 use crate::types::{HyperAST, NodeId, NodeStore, Tree, WithChildren};
+use crate::PrimInt;
 
 /// BottomUp content
 #[derive(Clone, Debug)]

--- a/hyper_ast/src/position/offsets_and_nodes.rs
+++ b/hyper_ast/src/position/offsets_and_nodes.rs
@@ -5,7 +5,7 @@ use crate::PrimInt;
 /// BottomUp content
 #[derive(Clone, Debug)]
 pub struct StructuralPosition<IdN, Idx, Config = tags::TopDownFull> {
-    pub(super) parents: Vec<IdN>, //parents? // most likely parents 
+    pub(super) parents: Vec<IdN>, //parents? // most likely parents
     pub(super) offsets: Vec<Idx>,
     _phantom: std::marker::PhantomData<Config>,
 }
@@ -14,7 +14,7 @@ impl<IdN, Idx, C> StructuralPosition<IdN, Idx, C> {
         Self {
             parents: vec![],
             offsets: vec![],
-            _phantom: Default::default()
+            _phantom: Default::default(),
         }
     }
     pub(crate) fn solved(self, node: IdN) -> SolvedStructuralPosition<IdN, Idx, C> {
@@ -22,8 +22,36 @@ impl<IdN, Idx, C> StructuralPosition<IdN, Idx, C> {
             parents: self.parents,
             offsets: self.offsets,
             node,
-            _phantom: Default::default()
+            _phantom: Default::default(),
         }
+    }
+}
+
+impl<IdN, Idx: PrimInt> super::position_accessors::WithOffsets for StructuralPosition<IdN, Idx> {
+    type Idx = Idx;
+}
+
+impl<IdN, Idx: PrimInt> super::position_accessors::WithPath<IdN> for StructuralPosition<IdN, Idx> {}
+
+impl<IdN, Idx: PrimInt> super::position_accessors::WithPreOrderOffsets
+    for StructuralPosition<IdN, Idx>
+{
+    type It<'a> = SPIter<'a, Idx> where Idx: 'a, Self: 'a;
+
+    fn iter_offsets(&self) -> Self::It<'_> {
+        let mut iter = self.offsets.iter();
+        iter.next().unwrap();
+        SPIter(iter)
+    }
+}
+
+pub struct SPIter<'a, Idx>(std::slice::Iter<'a, Idx>);
+
+impl<'a, Idx: PrimInt> Iterator for SPIter<'a, Idx> {
+    type Item = Idx;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|x| *x - num::one())
     }
 }
 
@@ -45,7 +73,7 @@ impl<IdN, Idx, C> From<SolvedStructuralPosition<IdN, Idx, C>> for StructuralPosi
         Self {
             parents: value.parents,
             offsets: value.offsets,
-            _phantom: Default::default()
+            _phantom: Default::default(),
         }
     }
 }
@@ -125,12 +153,12 @@ impl<IdN: Copy, Idx: PrimInt> TreePathMut<IdN, Idx> for StructuralPosition<IdN, 
     }
 }
 
-impl<IdN, Idx: num::Zero,C> StructuralPosition<IdN, Idx,C> {
+impl<IdN, Idx: num::Zero, C> StructuralPosition<IdN, Idx, C> {
     pub fn new(node: IdN) -> Self {
         Self {
             parents: vec![node],
             offsets: vec![num::zero()],
-            _phantom: Default::default()
+            _phantom: Default::default(),
         }
     }
 }
@@ -142,7 +170,7 @@ impl<IdN, Idx> From<(Vec<IdN>, Vec<Idx>, IdN)> for StructuralPosition<IdN, Idx> 
         Self {
             parents: x.0,
             offsets: x.1,
-            _phantom: Default::default()
+            _phantom: Default::default(),
         }
     }
 }
@@ -152,7 +180,7 @@ impl<IdN, Idx> From<(Vec<IdN>, Vec<Idx>)> for StructuralPosition<IdN, Idx> {
         Self {
             parents: x.0,
             offsets: x.1,
-            _phantom: Default::default()
+            _phantom: Default::default(),
         }
     }
 }
@@ -162,19 +190,15 @@ impl<IdN, Idx: num::Zero> From<IdN> for StructuralPosition<IdN, Idx> {
     }
 }
 
-
 mod impl_c_p_p_receivers {
-    use crate::position::building::bottom_up;
 
     use super::super::building;
     use super::PrimInt;
-    use building::top_down;
     use super::SolvedStructuralPosition;
     use super::StructuralPosition;
+    use building::top_down;
 
-    impl<IdN, Idx: PrimInt, C> top_down::CreateBuilder
-        for StructuralPosition<IdN, Idx, C>
-    {
+    impl<IdN, Idx: PrimInt, C> top_down::CreateBuilder for StructuralPosition<IdN, Idx, C> {
         fn create() -> Self {
             Self {
                 offsets: vec![],
@@ -184,9 +208,7 @@ mod impl_c_p_p_receivers {
         }
     }
 
-    impl<IdN, Idx: PrimInt, C> top_down::ReceiveParent<IdN, Self>
-        for StructuralPosition<IdN, Idx, C>
-    {
+    impl<IdN, Idx: PrimInt, C> top_down::ReceiveParent<IdN, Self> for StructuralPosition<IdN, Idx, C> {
         fn push(self, _parent: IdN) -> Self {
             self
         }
@@ -200,8 +222,7 @@ mod impl_c_p_p_receivers {
         }
     }
 
-    impl<IdN, Idx: PrimInt, C>
-        building::bottom_up::ReceiveDirName<Self>
+    impl<IdN, Idx: PrimInt, C> building::bottom_up::ReceiveDirName<Self>
         for StructuralPosition<IdN, Idx, C>
     {
         fn push(self, _dir_name: &str) -> Self {
@@ -216,8 +237,7 @@ mod impl_c_p_p_receivers {
     //     }
     // }
 
-    impl<IdN, Idx: PrimInt, C>
-        building::top_down::ReceiveIdx<Idx, Self>
+    impl<IdN, Idx: PrimInt, C> building::top_down::ReceiveIdx<Idx, Self>
         for StructuralPosition<IdN, Idx, C>
     {
         fn push(self, _idx: Idx) -> Self {
@@ -233,8 +253,7 @@ mod impl_c_p_p_receivers {
     //     }
     // }
 
-    impl<IdN, Idx: PrimInt, C>
-        building::top_down::ReceiveIdxNoSpace<Idx, Self>
+    impl<IdN, Idx: PrimInt, C> building::top_down::ReceiveIdxNoSpace<Idx, Self>
         for StructuralPosition<IdN, Idx, C>
     {
         fn push(mut self, idx: Idx) -> Self {
@@ -243,23 +262,18 @@ mod impl_c_p_p_receivers {
         }
     }
 
-    impl<IdN, Idx: PrimInt, C> top_down::FileSysReceiver
-        for StructuralPosition<IdN, Idx, C>
-    {
+    impl<IdN, Idx: PrimInt, C> top_down::FileSysReceiver for StructuralPosition<IdN, Idx, C> {
         type InFile<O> = Self;
     }
 
-    impl<IdN, Idx: PrimInt, IdO, C>
-        building::top_down::ReceiveOffset<IdO, Self>
+    impl<IdN, Idx: PrimInt, IdO, C> building::top_down::ReceiveOffset<IdO, Self>
         for StructuralPosition<IdN, Idx, C>
     {
         fn push(self, _bytes: IdO) -> Self {
             self
         }
     }
-    impl<IdN, Idx: PrimInt, IdO, C> building::SetLen<IdO, Self>
-        for StructuralPosition<IdN, Idx, C>
-    {
+    impl<IdN, Idx: PrimInt, IdO, C> building::SetLen<IdO, Self> for StructuralPosition<IdN, Idx, C> {
         fn set(self, _len: IdO) -> Self {
             self
         }
@@ -278,16 +292,12 @@ mod impl_c_p_p_receivers {
             self.solved(node)
         }
     }
-    impl<IdN, Idx: PrimInt, C> top_down::SetFileName<Self>
-        for StructuralPosition<IdN, Idx, C>
-    {
+    impl<IdN, Idx: PrimInt, C> top_down::SetFileName<Self> for StructuralPosition<IdN, Idx, C> {
         fn set_file_name(self, file_name: &str) -> Self {
             self
         }
     }
-    impl<IdN, Idx: PrimInt, C> building::Transition<Self>
-        for StructuralPosition<IdN, Idx, C>
-    {
+    impl<IdN, Idx: PrimInt, C> building::Transition<Self> for StructuralPosition<IdN, Idx, C> {
         fn transit(self) -> Self {
             self
         }

--- a/hyper_ast/src/position/spaces_related.rs
+++ b/hyper_ast/src/position/spaces_related.rs
@@ -306,7 +306,7 @@ where
         let mut no_spaces = vec![];
         let mut path = vec![];
         // iter offsets
-        let mut offsets_iter = self.src.iter();
+        let mut offsets_iter = self.src.iter_offsets();
         loop {
             let b = stores.node_store().resolve(&x);
             let t = stores.type_store().resolve_type(&b);
@@ -318,7 +318,7 @@ where
             }
 
             let (cs, o) = match (b.children(), offsets_iter.next()) {
-                (Some(cs), Some(o)) => (cs, o),
+                (Some(cs), Some(&o)) => (cs, o),
                 (None, Some(_)) => panic!("there is no children remaining"),
                 _ => break,
             };
@@ -373,7 +373,7 @@ where
     {
         let stores = self.stores;
         let mut x = self.src.root();
-        let mut offsets_iter = self.src.iter();
+        let mut offsets_iter = self.src.iter_offsets();
 
         let mut aaa = PathBuf::default();
         let mut offset = 0;
@@ -395,7 +395,7 @@ where
                 }
 
                 let (cs, o) = match (b.children(), offsets_iter.next()) {
-                    (Some(cs), Some(o)) => (cs.clone(), o),
+                    (Some(cs), Some(&o)) => (cs.clone(), o),
                     (None, Some(_)) => panic!("there is no children remaining"),
                     _ => return todo!(),
                 };
@@ -420,7 +420,7 @@ where
             assert!(!t.is_directory());
 
             let (cs, o) = match (b.children(), offsets_iter.next()) {
-                (Some(cs), Some(o)) => (cs.clone(), o),
+                (Some(cs), Some(&o)) => (cs.clone(), o),
                 (None, Some(_)) => panic!("there is no children remaining"),
                 _ => break (b, t),
             };
@@ -471,7 +471,7 @@ where
         let mut builder: B = Default::default();
         let stores = self.stores;
         let mut x = self.src.root();
-        let mut offsets_iter = self.src.iter();
+        let mut offsets_iter = self.src.iter_offsets();
 
         // let mut aaa = PathBuf::default();
         // let mut offset = 0;
@@ -497,7 +497,7 @@ where
                 };
 
                 let (cs, idx) = match (b.children(), offsets_iter.next()) {
-                    (Some(cs), Some(o)) => (cs.clone(), o),
+                    (Some(cs), Some(&o)) => (cs.clone(), o),
                     (None, Some(_)) => panic!("there is no children remaining"),
                     _ => return builder.finish(x),
                 };
@@ -514,7 +514,7 @@ where
             assert!(!t.is_directory());
 
             let (cs, idx) = match (b.children(), offsets_iter.next()) {
-                (Some(cs), Some(idx)) => (cs.clone(), idx),
+                (Some(cs), Some(&idx)) => (cs.clone(), idx),
                 (None, Some(_)) => panic!("there is no children remaining"),
                 _ => break (b, t),
             };
@@ -565,7 +565,7 @@ where
         let mut builder: B = building::top_down::CreateBuilder::create();
         let stores = self.stores;
         let mut x = self.src.root();
-        let mut offsets_iter = self.src.iter();
+        let mut offsets_iter = self.src.iter_offsets();
 
         // let mut aaa = PathBuf::default();
         // let mut offset = 0;
@@ -592,7 +592,7 @@ where
                 };
 
                 let (cs, idx) = match (b.children(), offsets_iter.next()) {
-                    (Some(cs), Some(o)) => (cs.clone(), o),
+                    (Some(cs), Some(&o)) => (cs.clone(), o),
                     (None, Some(_)) => panic!("there is no children remaining"),
                     _ => return builder.set_node(x),
                 };
@@ -610,7 +610,7 @@ where
             assert!(!t.is_directory());
 
             let (cs, idx) = match (b.children(), offsets_iter.next()) {
-                (Some(cs), Some(idx)) => (cs.clone(), idx),
+                (Some(cs), Some(&idx)) => (cs.clone(), idx),
                 (None, Some(_)) => panic!("there is no children remaining"),
                 _ => break (b, t),
             };

--- a/hyper_ast/src/position/spaces_related.rs
+++ b/hyper_ast/src/position/spaces_related.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use num::{one, zero, ToPrimitive};
 
 use super::Position;
-use super::PrimInt;
+use crate::PrimInt;
 use super::WithHyperAstPositionConverter;
 use crate::position::building;
 use crate::types::{
@@ -318,7 +318,7 @@ where
             }
 
             let (cs, o) = match (b.children(), offsets_iter.next()) {
-                (Some(cs), Some(&o)) => (cs, o),
+                (Some(cs), Some(o)) => (cs, o),
                 (None, Some(_)) => panic!("there is no children remaining"),
                 _ => break,
             };
@@ -395,7 +395,7 @@ where
                 }
 
                 let (cs, o) = match (b.children(), offsets_iter.next()) {
-                    (Some(cs), Some(&o)) => (cs.clone(), o),
+                    (Some(cs), Some(o)) => (cs.clone(), o),
                     (None, Some(_)) => panic!("there is no children remaining"),
                     _ => return todo!(),
                 };
@@ -420,7 +420,7 @@ where
             assert!(!t.is_directory());
 
             let (cs, o) = match (b.children(), offsets_iter.next()) {
-                (Some(cs), Some(&o)) => (cs.clone(), o),
+                (Some(cs), Some(o)) => (cs.clone(), o),
                 (None, Some(_)) => panic!("there is no children remaining"),
                 _ => break (b, t),
             };
@@ -497,7 +497,7 @@ where
                 };
 
                 let (cs, idx) = match (b.children(), offsets_iter.next()) {
-                    (Some(cs), Some(&o)) => (cs.clone(), o),
+                    (Some(cs), Some(o)) => (cs.clone(), o),
                     (None, Some(_)) => panic!("there is no children remaining"),
                     _ => return builder.finish(x),
                 };
@@ -514,7 +514,7 @@ where
             assert!(!t.is_directory());
 
             let (cs, idx) = match (b.children(), offsets_iter.next()) {
-                (Some(cs), Some(&idx)) => (cs.clone(), idx),
+                (Some(cs), Some(idx)) => (cs.clone(), idx),
                 (None, Some(_)) => panic!("there is no children remaining"),
                 _ => break (b, t),
             };
@@ -592,7 +592,7 @@ where
                 };
 
                 let (cs, idx) = match (b.children(), offsets_iter.next()) {
-                    (Some(cs), Some(&o)) => (cs.clone(), o),
+                    (Some(cs), Some(o)) => (cs.clone(), o),
                     (None, Some(_)) => panic!("there is no children remaining"),
                     _ => return builder.set_node(x),
                 };
@@ -610,7 +610,7 @@ where
             assert!(!t.is_directory());
 
             let (cs, idx) = match (b.children(), offsets_iter.next()) {
-                (Some(cs), Some(&idx)) => (cs.clone(), idx),
+                (Some(cs), Some(idx)) => (cs.clone(), idx),
                 (None, Some(_)) => panic!("there is no children remaining"),
                 _ => break (b, t),
             };

--- a/hyper_ast/src/position/structural_pos.rs
+++ b/hyper_ast/src/position/structural_pos.rs
@@ -1,4 +1,4 @@
-use super::{building, tags, Position, PrimInt, TreePath, WithHyperAstPositionConverter};
+use super::{building, tags, Position, TreePath, WithHyperAstPositionConverter};
 use std::{fmt::Debug, path::PathBuf};
 
 use num::one;
@@ -8,7 +8,7 @@ use crate::{
     types::{
         self, AnyType, Children, HyperAST, HyperType, IterableChildren, LabelStore, Labeled,
         NodeId, NodeStore, TypeStore, Typed, TypedNodeId, WithChildren, WithSerialization,
-    },
+    }, PrimInt,
 };
 
 pub use super::offsets_and_nodes::StructuralPosition;

--- a/hyper_ast/src/position/structural_pos/path_store.rs
+++ b/hyper_ast/src/position/structural_pos/path_store.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::{Position, PrimInt},
+    super::Position,
     ExploreStructuralPositions, Scout, SpHandle, StructuralPosition, StructuralPositionStore,
 };
 use crate::{
@@ -7,7 +7,7 @@ use crate::{
     store::defaults::LabelIdentifier,
     types::{
         self, AnyType, HyperAST, NodeId, NodeStore, Tree, Typed, WithChildren, WithSerialization,
-    },
+    }, PrimInt,
 };
 use num::{one, zero};
 use std::fmt::Debug;

--- a/hyper_ast/src/position/structural_pos/scouting.rs
+++ b/hyper_ast/src/position/structural_pos/scouting.rs
@@ -1,9 +1,10 @@
 use super::super::TreePathMut;
-use super::{Position, PrimInt, StructuralPosition, StructuralPositionStore, TreePath};
+use super::{Position, StructuralPosition, StructuralPositionStore, TreePath};
 use std::fmt::Debug;
 
 use num::{one, traits::NumAssign, zero};
 
+use crate::PrimInt;
 use crate::{
     store::defaults::LabelIdentifier,
     types::{

--- a/hyper_ast/src/position/structural_pos/typed_scouting.rs
+++ b/hyper_ast/src/position/structural_pos/typed_scouting.rs
@@ -1,6 +1,6 @@
 use super::super::{TreePathMut, TypedTreePath};
 use super::{
-    Position, PrimInt, Scout, SpHandle, StructuralPosition, StructuralPositionStore, TreePath,
+    Position, Scout, SpHandle, StructuralPosition, StructuralPositionStore, TreePath,
 };
 use std::{fmt::Debug, marker::PhantomData};
 
@@ -8,6 +8,7 @@ use num::zero;
 
 use crate::types::{Typed, TypedNodeId, WithChildren, NodeId};
 
+use crate::PrimInt;
 use crate::{
     store::defaults::LabelIdentifier,
     types::{self, HyperAST, WithSerialization},

--- a/hyper_ast/src/position/topological_offset.rs
+++ b/hyper_ast/src/position/topological_offset.rs
@@ -1,2 +1,2 @@
-use super::PrimInt;
+use crate::PrimInt;
 pub struct Position<T: PrimInt>(T);

--- a/hyper_ast/src/store/mod.rs
+++ b/hyper_ast/src/store/mod.rs
@@ -80,6 +80,19 @@ where
     }
 }
 
+impl<IdN, TS, NS, LS> crate::types::NodeStoreLean<IdN> for SimpleStores<TS, NS, LS>
+where
+    NS::R: crate::types::Tree<TreeId = IdN>,
+    IdN: crate::types::NodeId<IdN = IdN>,
+    NS: crate::types::NodeStoreLean<IdN>,
+{
+    type R = NS::R;
+
+    fn resolve(&self, id: &IdN) -> Self::R {
+        self.node_store.resolve(id)
+    }
+}
+
 impl<'store, TS, NS, LS> crate::types::LabelStore<str> for SimpleStores<TS, NS, LS>
 where
     LS: crate::types::LabelStore<str>,

--- a/hyper_ast/src/store/nodes/legion/mod.rs
+++ b/hyper_ast/src/store/nodes/legion/mod.rs
@@ -7,7 +7,7 @@ use legion::{
 };
 
 use crate::{
-    types::{NodeId, TypedNodeId},
+    types::{NodeId, Typed, TypedNodeId},
     utils::make_hash,
 };
 
@@ -165,6 +165,14 @@ impl NodeStore {
             .entry_ref(*id)
             .map(|x| HashedNodeRef::new(x))
             .unwrap()
+    }
+
+    pub fn resolve_with_type<T: 'static + TypedNodeId<IdN = NodeIdentifier>>(&self, id: &T::IdN) -> (T::Ty, HashedNodeRef<T>) {
+        let n = self.internal
+            .entry_ref(*id)
+            .map(|x| HashedNodeRef::new(x))
+            .unwrap();
+        (n.get_type(), n)
     }
 
     pub fn try_resolve(&self, id: NodeIdentifier) -> Option<HashedNodeRef<NodeIdentifier>> {

--- a/hyper_ast/src/types.rs
+++ b/hyper_ast/src/types.rs
@@ -4,7 +4,6 @@ use std::fmt::Display;
 use std::hash::Hash;
 use std::str::FromStr;
 
-use num::PrimInt;
 use num::ToPrimitive;
 use strum::IntoEnumIterator;
 use strum_macros::AsRefStr;
@@ -12,6 +11,8 @@ use strum_macros::Display;
 use strum_macros::EnumCount;
 use strum_macros::EnumIter;
 use strum_macros::EnumString;
+
+use crate::PrimInt;
 
 pub trait HashKind {
     fn structural() -> Self;

--- a/hyper_diff/src/actions/action_tree.rs
+++ b/hyper_diff/src/actions/action_tree.rs
@@ -1,5 +1,6 @@
+use hyper_ast::PrimInt;
+
 use crate::tree::tree_path::CompressedTreePath;
-use num_traits::PrimInt;
 /// WIP to better express variability in edit scripts actions order,
 /// action_vec only allow one order to apply actions.
 /// Maybe it can be integrated in the existing script generator or it needs major changes.
@@ -7,7 +8,7 @@ use num_traits::PrimInt;
 use std::fmt::Debug;
 
 use super::{
-    script_generator2::{Act, SimpleAction},
+    script_generator2::SimpleAction,
     Actions,
 };
 
@@ -44,7 +45,7 @@ impl<L, Idx: PrimInt, I> ActionsTree<SimpleAction<L, CompressedTreePath<Idx>, I>
         let mut i = 0;
         for x in r.iter_mut() {
             i += 1;
-            use crate::tree::tree_path::SharedPath;
+            use hyper_ast::position::position_accessors::SharedPath;
             match x.action.path.mid.shared_ancestors(&node.action.path.mid) {
                 SharedPath::Exact(_) => panic!(),
                 SharedPath::Remain(_) => panic!(),

--- a/hyper_diff/src/actions/script_generator2.rs
+++ b/hyper_diff/src/actions/script_generator2.rs
@@ -1,7 +1,8 @@
 /// inspired by the implementation in gumtree
 use std::{collections::HashSet, fmt::Debug, hash::Hash};
 
-use num_traits::{cast, PrimInt, ToPrimitive};
+use num_traits::{cast, ToPrimitive};
+use hyper_ast::PrimInt;
 
 use crate::{
     actions::Actions,
@@ -601,7 +602,7 @@ where
             .unwrap_or(&d); //self.src_arena.children(self.store, w);
         self.src_in_order.remove_all(&w_c);
         let x_c = self.dst_arena.children(self.store, x);
-        self.dst_in_order.remove_all(&x_c);
+        self.dst_in_order.remove_all(x_c.as_slice());
 
         // todo use iter filter collect
         let mut s1 = vec![];
@@ -831,7 +832,7 @@ struct Iter<'a, IdC, IdD: PrimInt> {
     mid_arena: &'a mut [MidNode<IdC, IdD>],
 }
 
-impl<'a, IdC, IdD: num_traits::PrimInt> Iterator for Iter<'a, IdC, IdD> {
+impl<'a, IdC, IdD: PrimInt> Iterator for Iter<'a, IdC, IdD> {
     type Item = IdD;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/hyper_diff/src/algorithms/gumtree.rs
+++ b/hyper_diff/src/algorithms/gumtree.rs
@@ -36,9 +36,8 @@ pub fn diff<'store, HAST: HyperAST<'store>>(
 >
 where
     HAST::IdN: Clone + Debug + Eq,
+    HAST::Idx: hyper_ast::PrimInt,
     HAST::Label: Debug + Clone + Copy,
-    // <HAST::T as types::Typed>::Type: Debug,
-    <HAST::T as types::WithChildren>::ChildIdx: Debug,
     HAST::T: 'store + types::WithHashs + types::WithStats,
 {
     let now = Instant::now();

--- a/hyper_diff/src/algorithms/gumtree_lazy.rs
+++ b/hyper_diff/src/algorithms/gumtree_lazy.rs
@@ -44,8 +44,7 @@ pub fn diff<'store, HAST: HyperAST<'store>>(
 where
     HAST::IdN: Clone + Debug + Eq,
     HAST::Label: Clone + Copy + Eq + Debug,
-    // <HAST::T as types::Typed>::Type: Eq + Debug,
-    <HAST::T as types::WithChildren>::ChildIdx: Debug,
+    HAST::Idx: hyper_ast::PrimInt,
     HAST::T: 'store + types::WithHashs + types::WithStats,
 {
     let now = Instant::now();

--- a/hyper_diff/src/algorithms/gumtree_partial_lazy.rs
+++ b/hyper_diff/src/algorithms/gumtree_partial_lazy.rs
@@ -40,8 +40,8 @@ pub fn diff<'store, HAST: HyperAST<'store>>(
 where
     HAST::IdN: Clone + Debug + Eq,
     HAST::Label: Clone + Copy + Eq + Debug,
+    HAST::Idx: hyper_ast::PrimInt,
     <HAST::T as types::Typed>::Type: Eq + Debug,
-    <HAST::T as types::WithChildren>::ChildIdx: Debug,
     HAST::T: 'store + types::Typed + types::WithHashs + types::WithStats,
 {
     let now = Instant::now();

--- a/hyper_diff/src/decompressed_tree_store/hidding_wrapper.rs
+++ b/hyper_diff/src/decompressed_tree_store/hidding_wrapper.rs
@@ -957,12 +957,12 @@ where
                 visited.set(llds[i].to_usize().unwrap(), true);
             }
         }
-        dbg!(
-            id_compressed.len(),
-            id_parent.len(),
-            llds.len(),
-            self.map.borrow().len()
-        );
+        // dbg!(
+        //     id_compressed.len(),
+        //     id_parent.len(),
+        //     llds.len(),
+        //     self.map.borrow().len()
+        // );
         CompleteWHPO {
             map: self.map.borrow(),
             id_compressed,

--- a/hyper_diff/src/decompressed_tree_store/lazy_post_order.rs
+++ b/hyper_diff/src/decompressed_tree_store/lazy_post_order.rs
@@ -476,7 +476,7 @@ impl<'d, T: WithChildren + WithStats, IdD: PrimInt + Shallow<IdD> + Debug> LazyP
 where
     T::TreeId: Clone + Eq + Debug + NodeId<IdN = T::TreeId>,
 {
-    pub fn child_decompressed<'b, S>(&mut self, store: &'b S, x: &IdD, p: &[T::ChildIdx]) -> IdD
+    pub fn child_decompressed<'b, S>(&mut self, store: &'b S, x: &IdD, p: impl Iterator<Item=T::ChildIdx>) -> IdD
     where
         S: NodeStore<T::TreeId, R<'b> = T>,
     {
@@ -485,7 +485,7 @@ where
             let cs = self.decompress_children(store, &r);
             let mut z: IdD = zero();
             let cs = cs
-                .get(..(*d + one()).to_usize().unwrap())
+                .get(..(d + one()).to_usize().unwrap())
                 .expect("no child corresponding to given path");
             for x in cs {
                 z = z + self._size(x); //Self::size2(store, x);

--- a/hyper_diff/src/decompressed_tree_store/mod.rs
+++ b/hyper_diff/src/decompressed_tree_store/mod.rs
@@ -176,6 +176,9 @@ pub trait DecompressedWithParent<'a, T: WithChildren, IdD> {
     fn parents(&self, id: IdD) -> Self::PIt<'_>;
     fn position_in_parent(&self, c: &IdD) -> Option<T::ChildIdx>;
     fn path(&self, parent: &IdD, descendant: &IdD) -> Vec<T::ChildIdx>;
+    fn path_rooted(&self, descendant: &IdD) -> Vec<T::ChildIdx> where Self: ShallowDecompressedTreeStore<'a, T, IdD> {
+        self.path(&self.root(), descendant)
+    }
     /// lowest common ancestor
     fn lca(&self, a: &IdD, b: &IdD) -> IdD;
     // fn position_in_parent<'b, S>(

--- a/hyper_diff/src/lib.rs
+++ b/hyper_diff/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(test)]
 pub mod actions;
 pub mod decompressed_tree_store;
+#[cfg(feature = "experimental")]
 pub mod mapping;
 pub mod matchers;
 pub mod tree;

--- a/hyper_diff/src/tree/tree_path.rs
+++ b/hyper_diff/src/tree/tree_path.rs
@@ -6,7 +6,8 @@
 //! - [ ] low compute cost extend
 use std::{fmt::Debug, marker::PhantomData};
 
-use num_traits::{cast, PrimInt, ToPrimitive};
+use hyper_ast::PrimInt;
+use num_traits::{cast, ToPrimitive};
 
 pub trait TreePath: IntoIterator {
     type ItemIterator<'a>: Iterator<Item = Self::Item>


### PR DESCRIPTION
Lot of refactorings of the tracking feature in client, later it should help with moving some code from client to hyper_diff.

I also worked on the Querying feature [gen/tree-sitter/query/](https://github.com/quentinLeDilavrec/HyperAST/tree/61b17106bd8b1ee49185afadd24324125d2b639e/gen/tree-sitter/query).
I added captures and predicates (only implemented "eq" for now, actually in vanilla tree sitter each binder implement their own, so I left this rabbit hole for another time when really needed).
There are now prototypes to do some meta stuff! most of them are still in [tests/auto.rs](https://github.com/quentinLeDilavrec/HyperAST/tree/61b17106bd8b1ee49185afadd24324125d2b639e/gen/tree-sitter/query/src/tests/auto.rs).
Like using queries to modify queries, merging predicates, and printing any ast as a query.