### PR TITLE
Nix Update

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,23 @@
+name: update-flake-lock # Documentation here: https://github.com/DeterminateSystems/update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 4 1 * *' # At 04:00 on day-of-month 1.
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@main
+        with:
+          pr-title: "Update flake.lock" # Title of PR to be created
+          pr-labels: |                  # Labels to be set on the PR
+            dependencies
+            automated
+          pr-assignees: Tol0kk
+          pr-reviewers: Tol0kk

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720535198,
-        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "lastModified": 1732350895,
+        "narHash": "sha256-GcOQbOgmwlsRhpLGSwZJwLbo3pu9ochMETuRSS1xpz4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "rev": "0c582677378f2d9ffcb01490af2f2c678dcb29d3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722997267,
-        "narHash": "sha256-8Pncp8IKd0f0N711CRrCGTC4iLfBE+/5kaMqyWxnYic=",
+        "lastModified": 1732847586,
+        "narHash": "sha256-SnHHSBNZ+aj8mRzYxb6yXBl9ei3K3j5agC/D8Vjw/no=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d720bf3cebac38c2426d77ee2e59943012854cb8",
+        "rev": "97210ddff72fe139815f4c1ac5da74b5b0dde2d7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,12 @@
   description = "HyperAST";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs = {
         nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
       };
     };
   };
@@ -39,36 +38,53 @@
             release = true;
             doCheck = false;
             buildInputs = with pkgs; [
+              # misc libraries
               openssl
             ];
             nativeBuildInputs = with pkgs; [
+              # misc libraries
               cmake
               pkg-config
+              
+              # Rust
               (rust-bin.fromRustupToolchainFile ./rust-toolchain)
             ];
             cargoLock = {
               lockFile = ./Cargo.lock;
-              outputHashes = {
-                "tree-sitter-cpp-0.20.0" = "sha256-bRHI/zQgBKiaHD+erO8gCCxLAX+qePRZOkTlva/Dcx0=";
-                "tree-sitter-java-0.20.9" = "sha256-lb3dJJs9QEu1qkuhbJn7ssy6wg0lxhDI9KGcYWOD0FM=";
-                "tree-sitter-typescript-0.20.3" = "sha256-q8vJnJZdWzsiHHJSPGoM938U5AxuOIuGrx1r6F+cdK4=";
-                "tree-sitter-xml-0.20.9" = "sha256-fG5tdBzOigZkRjdR2WLCBWM3pQYTLoNIxLd0B4G+2cM=";
-              };
+              allowBuiltinFetchGit = true;
             };
           };
         };
 
         devShell = pkgs.mkShell rec {
           buildInputs = with pkgs; [
+            # Rust 
             (rust-bin.fromRustupToolchainFile ./rust-toolchain)
-            pkg-config
-            nixfmt
-            cmake
             trunk
+            
+            # misc
+            pkg-config
+
+            # Nix
+            nixfmt
           ];
           libraries = with pkgs; [
+            # x11 libraries
+            xorg.libXcursor
+            xorg.libXrandr
+            xorg.libXi
+            xorg.libX11
+
+            # wayland libraries
+            wayland
+            
+            # GUI libraries
+            libxkbcommon
+            libGL
+            fontconfig
+
+            # misc libraries
             openssl
-            glibc
           ];
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath libraries;
         };


### PR DESCRIPTION
Changes:
- Fix core-dump when entering nix devshell (remove glibc)
- Fix hard-coded hash in the flake.nix
- Add new GitHub Workflow for automatic update of the flake.lock
  - Would be nice to have some test to run to validate the  generated PR automatically. 