### PR TITLE
measuring parsing and processing (dedup + preprocessing) time for c++ 

### DIFF
--- a/cvs/git/src/cpp.rs
+++ b/cvs/git/src/cpp.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use crate::{
     preprocessed::IsSkippedAna, processing::ObjectName, Accumulator, BasicDirAcc,
     PROPAGATE_ERROR_ON_BAD_CST_NODE,
@@ -14,11 +16,47 @@ use hyper_ast_gen_ts_cpp::{
     types::{TStore, Type},
 };
 
+// waiting for residual stabilization https://github.com/rust-lang/rust/issues/84277
+// see after the temporary solution
+// It is also limiting the usability with more variants
+// enum FileProcessingResult<N, D = Duration> {
+//     FailedParsing {
+//         parsing_time: D,
+//         tree: tree_sitter::Tree,
+//         error: &'static str,
+//     },
+//     // ParsingTimedout(D),
+//     // FailedProcessing {
+//     //     parsing_time: D,
+//     //     processing_time: D,
+//     //     node: N,
+//     // },
+//     Success {
+//         parsing_time: D,
+//         processing_time: D,
+//         node: N,
+//     },
+// }
+
+pub struct FailedParsing<D = Duration> {
+    pub parsing_time: D,
+    pub tree: tree_sitter::Tree,
+    pub error: &'static str,
+}
+
+pub struct SuccessProcessing<N, D = Duration> {
+    pub parsing_time: D,
+    pub processing_time: D,
+    pub node: N,
+}
+
+pub type FileProcessingResult<N, D = Duration> = Result<SuccessProcessing<N, D>, FailedParsing<D>>;
+
 pub(crate) fn handle_cpp_file<'stores, 'cache, 'b: 'stores, More>(
     tree_gen: &mut cpp_tree_gen::CppTreeGen<'stores, 'cache, TStore, More>,
     name: &ObjectName,
     text: &'b [u8],
-) -> Result<cpp_tree_gen::FNode, ()>
+) -> FileProcessingResult<cpp_tree_gen::FNode>
 where
     More: tree_gen::Prepro<Type>
         + for<'a, 'c> tree_gen::More<
@@ -26,19 +64,43 @@ where
             cpp_tree_gen::Acc,
         >,
 {
-    let tree = match cpp_tree_gen::CppTreeGen::<TStore>::tree_sitter_parse(text) {
-        Ok(tree) => tree,
-        Err(tree) => {
-            log::warn!("bad CST: {:?}", name.try_str());
-            // log::debug!("{}", tree.root_node().to_sexp());
-            if PROPAGATE_ERROR_ON_BAD_CST_NODE {
-                return Err(());
-            } else {
-                tree
-            }
+    // handling the parsing explicitly in this function is a good idea
+    // to control complex stuff like timeout, instead of the call on next line
+    // let tree_sitter_parse = cpp_tree_gen::CppTreeGen::<TStore>::tree_sitter_parse(text);
+
+    let mut parser = tree_sitter::Parser::new();
+    // TODO see if a timeout of a cancellation flag could be useful
+    // const MINUTE: u64 = 60 * 1000 * 1000;
+    // parser.set_timeout_micros(MINUTE);
+    // parser.set_cancellation_flag(flag);
+    parser
+        .set_language(&hyper_ast_gen_ts_cpp::language())
+        .unwrap();
+    let time = Instant::now();
+    let tree = parser.parse(text, None);
+    let parsing_time = time.elapsed();
+    let Some(tree) = tree else {
+        unimplemented!("You set a timeout or an cancel flag, so it now requires special handling.")
+        // return FileProcessingResult::ParsingTimedout(parsing_time)
+    };
+    if tree.root_node().has_error() {
+        log::warn!("bad CST: {:?}", name.try_str());
+        if PROPAGATE_ERROR_ON_BAD_CST_NODE {
+            return Err(FailedParsing {
+                parsing_time,
+                tree,
+                error: "CST contains parsing errors",
+            });
         }
     };
-    Ok(tree_gen.generate_file(name.as_bytes(), text, tree.walk()))
+    let time = Instant::now();
+    let subtree = tree_gen.generate_file(name.as_bytes(), text, tree.walk());
+    let processing_time = time.elapsed();
+    Ok(SuccessProcessing {
+        parsing_time,
+        processing_time,
+        node: subtree,
+    })
 }
 
 pub struct CppAcc {

--- a/cvs/git/src/cpp_processor.rs
+++ b/cvs/git/src/cpp_processor.rs
@@ -7,7 +7,10 @@ use crate::{
     Processor,
 };
 use git2::{Oid, Repository};
-use hyper_ast::{store::nodes::legion::eq_node, types::{ETypeStore as _, LabelStore}};
+use hyper_ast::{
+    store::nodes::legion::eq_node,
+    types::{ETypeStore as _, LabelStore},
+};
 use hyper_ast_gen_ts_cpp::{
     legion as cpp_gen,
     types::{CppEnabledTypeStore as _, Type},
@@ -297,7 +300,7 @@ impl RepositoryProcessor {
                     .main_stores
                     .mut_with_ts::<hyper_ast_gen_ts_cpp::types::TStore>();
                 let more = &cpp_proc.query.0;
-                crate::cpp::handle_cpp_file(
+                let x = crate::cpp::handle_cpp_file(
                     &mut cpp_gen::CppTreeGen {
                         line_break,
                         stores,
@@ -307,8 +310,11 @@ impl RepositoryProcessor {
                     n,
                     t,
                 )
-                .map_err(|_| crate::ParseErr::IllFormed)
-                .map(|x| (x.local.clone(), false))
+                .map_err(|_| crate::ParseErr::IllFormed)?;
+                let local = x.local.clone();
+                self.parsing_time += x.parsing_time;
+                self.processing_time += x.processing_time;
+                Ok((local, false))
             })
     }
 

--- a/cvs/git/src/preprocessed.rs
+++ b/cvs/git/src/preprocessed.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{HashMap, HashSet},
     iter::Peekable,
     path::{Components, PathBuf},
-    time::Instant,
+    time::{Duration, Instant},
     todo, usize,
 };
 
@@ -42,6 +42,8 @@ pub struct PreProcessedRepository {
 pub struct RepositoryProcessor {
     pub main_stores: SimpleStores,
     pub processing_systems: crate::processing::erased::ProcessorMap,
+    pub parsing_time: Duration,
+    pub processing_time: Duration,
 }
 // NOTE what about making a constraints between sys processors
 // it should be a 1..n relation so it must be impl on the target

--- a/hyper_ast/src/position/computing_offset_top_down.rs
+++ b/hyper_ast/src/position/computing_offset_top_down.rs
@@ -411,6 +411,9 @@ impl StructuralPosition<NodeIdentifier, u16> {
                 }
             }
         } else {
+            if i == 0 {
+                i += 1;
+            }
             let p = self.parents[i - 1];
             let b = stores.node_store().resolve(&p);
             let o = self.offsets[i];


### PR DESCRIPTION
from my early experiments parsing take 1/5 of the run time. So just parallelising parsing might not be worth it.

eg. on chrome/ dir of chromium project:

parsing_time: 41.101130714
processing_time: 229.434112639