### PR TITLE
fix stupid desync with acceses to no space children

### DIFF
--- a/hyper_ast/src/store/nodes/legion/elem.rs
+++ b/hyper_ast/src/store/nodes/legion/elem.rs
@@ -561,9 +561,8 @@ impl<'a, T> HashedNodeRef<'a, T> {
     ) -> Result<&<Self as crate::types::WithChildren>::Children<'_>, ComponentError> {
         self.0
             .get_component::<NoSpacesCS<legion::Entity>>()
-            .map(|x| &*x.0)
-            .or_else(|_| self.0.get_component::<CS<legion::Entity>>().map(|x| &*x.0))
-            .map(|x| (*x).into())
+            .map(|x| (*x.0).into())
+            .or_else(|_| self.cs())
     }
 }
 


### PR DESCRIPTION
found because it was breaking decompression of tree while hidding spaces

for easy maintenance be more cautious with duplicating stuff than could change in the future, this fix is actually doing the reuse.