### PR TITLE
Fix nix hyperast-dockerImage and migrate to crane

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,7 +48,40 @@
         "type": "github"
       }
     },
+    "nix2container": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1775487831,
+        "narHash": "sha256-2lguQpLPQaxpQCJjXhmEEAfabwsAhkP29Z7fgLzHARA=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "76be9608a7f4d6c985d28b0e7be903ae2547df3e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1767028467,
+        "narHash": "sha256-7G+2aXClSMaTY1ogpX14CAxjRsvyVzpE0GRwL71WO7g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1cabc318c11299f07ca53e3cb719854682fe6eb3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1780203844,
         "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
@@ -64,7 +97,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -85,13 +118,14 @@
         "crane": "crane",
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs",
+        "nix2container": "nix2container",
+        "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1779992051,

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1780532242,
+        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -67,6 +82,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
     rust-overlay.url = "github:oxalica/rust-overlay?ref=stable";
     nix-filter.url = "github:numtide/nix-filter";
     crane.url = "github:ipetkov/crane";
+    nix2container.url = "github:nlewo/nix2container";
   };
 
   outputs =
@@ -16,6 +17,7 @@
       flake-utils,
       crane,
       rust-overlay,
+      nix2container,
       ...
     }@inputs:
     flake-utils.lib.eachDefaultSystem (
@@ -95,6 +97,31 @@
                 "--"
                 "0.0.0.0:8888"
               ];
+              Env = [
+                "GIT_SSL_CAINFO=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+              ];
+            };
+          };
+          hyperast-ociImage = nix2container.packages.${system}.nix2container.buildImage {
+            name = "hyperast";
+            tag = "0.5.0";
+
+            copyToRoot = [
+              (pkgs.runCommand "symlinks" { } ''
+                mkdir -p $out
+                ln -s ${hyperast-backend}/bin/backend $out/backend
+                ln -s ${hyperast-backend}/bin/scripting $out/scripting
+              '')
+            ];
+
+            config = {
+              Cmd = [
+                "/backend"
+                "--"
+                "0.0.0.0:8888"
+              ];
+
               Env = [
                 "GIT_SSL_CAINFO=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
                 "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"

--- a/flake.nix
+++ b/flake.nix
@@ -6,23 +6,29 @@
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay.url = "github:oxalica/rust-overlay?ref=stable";
     nix-filter.url = "github:numtide/nix-filter";
+    crane.url = "github:ipetkov/crane";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    flake-utils,
-    rust-overlay,
-    ...
-  } @ inputs:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      crane,
+      rust-overlay,
+      ...
+    }@inputs:
     flake-utils.lib.eachDefaultSystem (
-      system: let
-        overlays = [(import rust-overlay)];
+      system:
+      let
+        overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs {
           inherit system overlays;
         };
         filter = inputs.nix-filter.lib;
-        hyperast-backend = pkgs.rustPlatform.buildRustPackage {
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+        commonArgs = {
           pname = "HyperAST";
           version = "0.5.0";
           src = filter {
@@ -38,31 +44,27 @@
               ./README.md
             ];
           };
-          buildAndTestSubdir = "crates/backend";
-          OPENSSL_NO_VENDOR = 1;
-          release = true;
+          strictDeps = true;
+          OPENSSL_NO_VENDOR = "1";
           doCheck = false;
-          buildInputs = with pkgs; [
-            # misc libraries
-            openssl
-            cacert
-          ];
+          buildInputs = with pkgs; [ openssl ];
           nativeBuildInputs = with pkgs; [
-            # misc libraries
             cmake
             pkg-config
-            openssl
-            cacert
-
-            # Rust
-            (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
           ];
-          cargoLock = {
-            lockFile = ./Cargo.lock;
-            allowBuiltinFetchGit = true;
-          };
+          CARGO_PROFILE_RELEASE_STRIP = "symbols";
+          cargoExtraArgs = "-p backend"; # builds both `backend` and `scripting` bins
         };
-      in {
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+        hyperast-backend = craneLib.buildPackage (
+          commonArgs
+          // {
+            inherit cargoArtifacts;
+          }
+        );
+      in
+      {
         apps = {
           hyperast-backend = {
             type = "app";
@@ -80,12 +82,19 @@
           hyperast-dockerImage = pkgs.dockerTools.buildLayeredImage {
             name = "HyperAST";
             tag = "0.5.0";
-            runAsRoot = ''
-              ln -s  ${hyperast-backend}/bin/scripting /scripting
-              ln -s  ${hyperast-backend}/bin/backend /backend
-            '';
+            contents = [
+              (pkgs.runCommand "symlinks" { } ''
+                mkdir -p $out
+                ln -s ${hyperast-backend}/bin/scripting $out/scripting
+                ln -s ${hyperast-backend}/bin/backend $out/backend
+              '')
+            ];
             config = {
-              Cmd = ["/backend -- 0.0.0.0:8888"];
+              Cmd = [
+                "/backend"
+                "--"
+                "0.0.0.0:8888"
+              ];
               Env = [
                 "GIT_SSL_CAINFO=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
                 "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"


### PR DESCRIPTION
The migration to Crane reduces the generated Docker image tarball to 33MB (100MB uncompressed) and significantly reduce build time, and better incremental build. 
I also removed `runAsRoot` since it was actually bad practice since it had to run the command through KVM only to add symlinks. 

To build the image:
```sh
nix build .#hyperast-dockerImage
```

To load the image:
```sh
docker load -i result
```

To run the image:
```sh
docker run -p 8888:8888 hyperast:0.5.0
```